### PR TITLE
Transport may incorrectly place headers inside $response variable.

### DIFF
--- a/class/transport.php
+++ b/class/transport.php
@@ -38,7 +38,8 @@ class CS_REST_BaseTransport {
     }
     
     function split_and_inflate($response, $may_be_compressed) {        
-        list( $headers, $result ) = explode("\r\n\r\n", $response, 2);
+	$ra = explode("\r\n\r\n", $response);
+	list( $result, $headers ) = array( array_pop($ra), array_pop($ra) );
         if($may_be_compressed && preg_match('/^Content-Encoding:\s+gzip\s+$/im', $headers)) {        
             $original_length = strlen($response);
             $result = gzinflate(substr($result, 10, -8));


### PR DESCRIPTION
HTTP responses may begin with "HTTP/1.1 Continue" (followed by a new line). The existing code assumes only a single header group, which can result in assigning final HTTP headers to $response variable. I noticed it with CS_REST_Subscribers import() method, I am not sure if it affected other methods.

This 2-line fix explode()s the response on "\r\n\r\n" (newline,blankline) into a variable. Next, the response is  array_pop()ed first, then the headers, each into their respective variables. This seemed to be the fastest method. The rest of the array is discarded. 
