### PR TITLE
Add default timeout to curl calls

### DIFF
--- a/class/transport.php
+++ b/class/transport.php
@@ -5,6 +5,7 @@ define('CS_REST_POST', 'POST');
 define('CS_REST_PUT', 'PUT');
 define('CS_REST_DELETE', 'DELETE');
 define('CS_REST_SOCKET_TIMEOUT', 1);
+define('CS_REST_CALL_TIMEOUT', 10);
 
 function CS_REST_TRANSPORT_get_available($requires_ssl, $log) {
     if(function_exists('curl_init') && function_exists('curl_exec')) {
@@ -88,6 +89,8 @@ class CS_REST_CurlTransport extends CS_REST_BaseTransport {
         curl_setopt($ch, CURLOPT_USERPWD, $call_options['credentials']);
         curl_setopt($ch, CURLOPT_USERAGENT, $call_options['userAgent']);
         curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: '.$call_options['contentType']));
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, CS_REST_SOCKET_TIMEOUT * 1000);
+        curl_setopt($ch, CURLOPT_TIMEOUT_MS, CS_REST_CALL_TIMEOUT * 1000);
 
         $headers = array();
         $inflate_response = false;


### PR DESCRIPTION
I've added a simple define CS_REST_CALL_TIMEOUT next to CS_REST_SOCKET_TIMEOUT. The curl transport wasn't respecting the SOCKET_TIMEOUT (have now mapped it on to CURLOPT_CONNECTTIMEOUT) and it was possible when using the curl transport through a flakey proxy for it to hang pretty much forever on API calls. The PHP Curl library enforces no real default timeout once connected.

The transfer timeout defaults to 10 seconds.

I know I could've accomplished this by injecting a custom transport, but I thought the greater good would be to push this upstream.
