### PR TITLE
Added support for getting an external session login URL.

### DIFF
--- a/csrest_general.php
+++ b/csrest_general.php
@@ -189,21 +189,41 @@ class CS_REST_General extends CS_REST_Wrapper_Base {
     }
     
     /**
-     * retrieves the email address of the primary contact for this account
+     * Retrieves the email address of the primary contact for this account
      * @return CS_REST_Wrapper_Result a successful response will be an array in the form:
      * 		array('EmailAddress'=> email address of primary contact)
      */
     function get_primary_contact() {
     	return $this->get_request($this->_base_route.'primarycontact.json');
     }
-    
+
     /**
-     * assigns the primary contact for this account to the administrator with the specified email address
-     * @param string $emailAddress the email address of the administrator designated to be the primary contact
+     * Assigns the primary contact for this account to the administrator with the specified email address
+     * @param $emailAddress string The email address of the administrator designated to be the primary contact
      * @return CS_REST_Wrapper_Result a successful response will be an array in the form:
      * 		array('EmailAddress'=> email address of primary contact)
      */
     function set_primary_contact($emailAddress) {
     	return $this->put_request($this->_base_route.'primarycontact.json?email=' . urlencode($emailAddress), '');
+    }
+
+    /**
+     * Get a URL which initiates a new external session for the user with the given email.
+     * Full details: http://www.campaignmonitor.com/api/account/#single_sign_on
+     *
+     * @param $session_options array Options for initiating the external login session.
+     *        This should be an array of the form:
+     *        array(
+     *          'Email' => 'The email address of the Campaign Monitor user for whom the login session should be created',
+     *          'Chrome' => 'Which 'chrome' to display - Must be either "all", "tabs", or "none"',
+     *          'Url' => 'The URL to display once logged in. e.g. "/subscribers/"',
+     *          'IntegratorID' => 'The Integrator ID. You need to contact Campaign Monitor support to get an Integrator ID.',
+     *          'ClientID' => 'The Client ID of the client which should be active once logged in to the Campaign Monitor account.' )
+     *
+     * @return CS_REST_Wrapper_Result A successful response will be an array of the form:
+     * 		array('SessionUrl'=> 'https://external1.createsend.com/cd/create/ABCDEF12/DEADBEEF?url=FEEDDAD1')
+     */
+    function external_session_url($session_options) {
+        return $this->put_request($this->_base_route.'externalsession.json', $session_options);
     }
 }

--- a/samples/external_session_url.php
+++ b/samples/external_session_url.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once '../csrest_general.php';
+
+$auth = array(
+    'access_token' => 'your access token',
+    'refresh_token' => 'your refresh token');
+$wrap = new CS_REST_General($auth);
+
+$result = $wrap->external_session_url(array(
+    'Email' => 'The email address of the Campaign Monitor user for whom the login session should be created',
+    'Chrome' => 'Which chrome to display - Must be either "all", "tabs", or "none"',
+    'Url' => 'The URL to display once logged in. e.g. "/subscribers/"',
+    'IntegratorID' => 'The Integrator ID. You need to contact Campaign Monitor support to get an Integrator ID.',
+    'ClientID' => 'The Client ID of the client which should be active once logged in to the Campaign Monitor account.'
+));
+
+echo "Result of PUT /api/v3/externalsession\n<br />";
+if($result->was_successful()) {
+    echo "Succeeded with Code ".$result->http_status_code."\n<br /><pre>";
+    var_dump($result->response);
+    echo '</pre>';
+} else {
+    echo 'Failed with code '.$result->http_status_code."\n<br /><pre>";
+    var_dump($result->response);
+    echo '</pre>';
+}

--- a/tests/csrest_test.php
+++ b/tests/csrest_test.php
@@ -242,7 +242,7 @@ abstract class CS_REST_TestGeneral extends CS_REST_TestBase {
         $this->general_test('get_primary_contact', $call_options,
             $raw_result, $deserialized);
     }
-    
+
     function testset_primary_contact() {
         $raw_result = '';
         $response_code = 200;
@@ -261,6 +261,34 @@ abstract class CS_REST_TestGeneral extends CS_REST_TestBase {
             $raw_result, $raw_result, '', '', $response_code);
 
         $result = $this->wrapper->set_primary_contact($email);
+
+        $this->assertIdentical($expected_result, $result);
+    }
+
+    function testset_external_session_url() {
+        $session_options = array(
+            'Email' => "exammple@example.com",
+            'Chrome' => "None",
+            'Url' => "/subscribers",
+            'IntegratorID' => "qw989q8wud98qwyd",
+            'ClientID' => "9q8uw9d8u9wud" );
+        $raw_result = '';
+        $response_code = 200;
+        $call_options = $this->get_call_options($this->base_route.'externalsession.json', 'PUT');
+        $call_options['data'] = 'session options were serialised to this';
+
+        $transport_result = array (
+            'code' => $response_code,
+            'response' => $raw_result
+        );
+
+        $expected_result = new CS_REST_Wrapper_Result($raw_result, $response_code);
+
+        $this->setup_transport_and_serialisation($transport_result, $call_options,
+            $raw_result, $raw_result, 'session options were serialised to this',
+            $session_options, $response_code);
+
+        $result = $this->wrapper->external_session_url($session_options);
 
         $this->assertIdentical($expected_result, $result);
     }


### PR DESCRIPTION
Added support for the feature which allows an API caller to get a URL which initiates a login for an external Campaign Monitor session. API docs: http://www.campaignmonitor.com/api/account/#single_sign_on
