### PR TITLE
Update create.php

### DIFF
--- a/samples/list/create.php
+++ b/samples/list/create.php
@@ -10,7 +10,7 @@ $wrap = new CS_REST_Lists(NULL, $auth);
 $result = $wrap->create('Lists Client ID', array(
     'Title' => 'List Title',
     'UnsubscribePage' => 'List unsubscribe page',
-    'ConfirmedOptIn' => true,
+    'ConfirmedOptIn' => false,
     'ConfirmationSuccessPage' => 'List confirmation success page',
     'UnsubscribeSetting' => CS_REST_LIST_UNSUBSCRIBE_SETTING_ALL_CLIENT_LISTS
 ));


### PR DESCRIPTION
I was playing around with the API (creating lists and uploading subscribers) and an email (unexpectedly) went out to all my subscribers because `ConfirmedOptIn` was `true`.  Perhaps its better to change this option to `false` in the example so that customers starting out with the API don't inadvertently email out to subscribers while playing around with the API.

Thanks,
Oleg
