### PR TITLE
use false for the resubscribe option in import example

### DIFF
--- a/samples/subscriber/import.php
+++ b/samples/subscriber/import.php
@@ -52,7 +52,7 @@ $result = $wrap->import(array(
 	        )
 	    )
 	)
-), true);
+), false);
 
 echo "Result of POST /api/v3/subscribers/{list id}/import.{format}\n<br />";
 if($result->was_successful()) {


### PR DESCRIPTION
I updated the import example to use `false` instead of `true` for the `Resubscribe` option.

`false` is the behavior on the campaign monitor website and just seems _safer_.
