### PR TITLE
don't let class_exists attempt to autoload the class

### DIFF
--- a/class/serialisation.php
+++ b/class/serialisation.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!class_exists('Services_JSON')) {
+if (!class_exists('Services_JSON', false)) {
     require_once dirname(__FILE__).'/services_json.php';
 }
 


### PR DESCRIPTION
This can potentially cause problems when folks have autoloaders installed that don't react well to random 3rd party autoload requests that they aren't configured to handle.
