### PR TITLE
Wrapped timeout constants in conditional checks

### DIFF
--- a/class/transport.php
+++ b/class/transport.php
@@ -4,8 +4,12 @@ define('CS_REST_GET', 'GET');
 define('CS_REST_POST', 'POST');
 define('CS_REST_PUT', 'PUT');
 define('CS_REST_DELETE', 'DELETE');
-define('CS_REST_SOCKET_TIMEOUT', 10);
-define('CS_REST_CALL_TIMEOUT', 10);
+if (false === defined('CS_REST_SOCKET_TIMEOUT')) {
+    define('CS_REST_SOCKET_TIMEOUT', 10);
+}
+if (false === defined('CS_REST_CALL_TIMEOUT')) {
+    define('CS_REST_CALL_TIMEOUT', 10);
+}
 
 function CS_REST_TRANSPORT_get_available($requires_ssl, $log) {
     if(function_exists('curl_init') && function_exists('curl_exec')) {


### PR DESCRIPTION
CS_REST_SOCKET_TIMEOUT and CS_REST_CALL_TIMEOUT constant definitions are now wrapped in conditional checks to see if the values have been defined earlier to allow larger requests to not timeout.

This was needed to allow subscriber imports to function without timing out.
