### PR TITLE
Changed all deprecated constructors to new __construct constructors

### DIFF
--- a/class/base_classes.php
+++ b/class/base_classes.php
@@ -29,7 +29,7 @@ class CS_REST_Wrapper_Result {
      */
     var $http_status_code;
 
-    function CS_REST_Wrapper_Result($response, $code) {
+    function __construct($response, $code) {
         $this->response = $response;
         $this->http_status_code = $code;
     }
@@ -127,7 +127,7 @@ class CS_REST_Wrapper_Base {
      * @param $transport The transport to use. Used for dependency injection
      * @access public
      */
-    function CS_REST_Wrapper_Base(
+    function __construct(
         $auth_details,
         $protocol = 'https',
         $debug_level = CS_REST_LOG_NONE,

--- a/class/log.php
+++ b/class/log.php
@@ -7,7 +7,7 @@ define('CS_REST_LOG_NONE', 0);
 class CS_REST_Log {
     var $_level;
 
-    function CS_REST_Log($level) {
+    function __construct($level) {
         $this->_level = $level;
     }
 

--- a/class/serialisation.php
+++ b/class/serialisation.php
@@ -16,7 +16,7 @@ class CS_REST_BaseSerialiser {
 
     var $_log;
     
-    function CS_REST_BaseSerialiser($log) { 
+    function __construct($log) {
         $this->_log = $log;
     }
     
@@ -47,7 +47,6 @@ class CS_REST_BaseSerialiser {
 }
 
 class CS_REST_DoNothingSerialiser extends CS_REST_BaseSerialiser {
-    function CS_REST_DoNothingSerialiser() {}
     function get_type() { return 'do_nothing'; }
     function serialise($data) { return $data; }
     function deserialise($text) {
@@ -58,10 +57,6 @@ class CS_REST_DoNothingSerialiser extends CS_REST_BaseSerialiser {
 }
 
 class CS_REST_NativeJsonSerialiser extends CS_REST_BaseSerialiser {
-
-    function CS_REST_NativeJsonSerialiser($log) {
-        $this->CS_REST_BaseSerialiser($log);
-    }
 
     function get_format() {
         return 'json';
@@ -99,8 +94,8 @@ class CS_REST_ServicesJsonSerialiser extends CS_REST_BaseSerialiser {
     
     var $_serialiser;
     
-    function CS_REST_ServicesJsonSerialiser($log) {
-        $this->CS_REST_BaseSerialiser($log);
+    function __construct($log) {
+        parent::__construct($log);
         $this->_serialiser = new Services_JSON();
     }
 

--- a/class/services_json.php
+++ b/class/services_json.php
@@ -129,7 +129,7 @@ class Services_JSON
     *                                   bubble up with an error, so all return values
     *                                   from encode() should be checked with isError()
     */
-    function Services_JSON($use = 0)
+    function __construct($use = 0)
     {
         $this->use = $use;
     }
@@ -772,8 +772,8 @@ class Services_JSON
 
 class Services_JSON_Error
 {
-    function Services_JSON_Error($message = 'unknown error', $code = null,
-                                 $mode = null, $options = null, $userinfo = null)
+    function __construct($message = 'unknown error', $code = null,
+                         $mode = null, $options = null, $userinfo = null)
     {
 
     }

--- a/class/transport.php
+++ b/class/transport.php
@@ -38,7 +38,7 @@ class CS_REST_BaseTransport {
     
     var $_log;
     
-    function CS_REST_BaseTransport($log) {
+    function __construct($log) {
         $this->_log = $log;
     }
     
@@ -58,6 +58,7 @@ class CS_REST_BaseTransport {
         
         return array($headers, $result); 
     }
+
 }
 /**
  * Provide HTTP request functionality via cURL extensions
@@ -69,8 +70,8 @@ class CS_REST_CurlTransport extends CS_REST_BaseTransport {
 
     var $_curl_zlib;
 
-    function CS_REST_CurlTransport($log) {
-        $this->CS_REST_BaseTransport($log);
+    function __construct($log) {
+        parent::__construct($log);
         
         $curl_version = curl_version();
         $this->_curl_zlib = isset($curl_version['libz_version']);
@@ -217,8 +218,8 @@ class CS_REST_SocketTransport extends CS_REST_BaseTransport {
 
     var $_socket_wrapper;
 
-    function CS_REST_SocketTransport($log, $socket_wrapper = NULL) {
-        $this->CS_REST_BaseTransport($log);
+    function __construct($log, $socket_wrapper = NULL) {
+        parent::__construct($log);
 
         if(is_null($socket_wrapper)) {
             $socket_wrapper = new CS_REST_SocketWrapper();

--- a/csrest_administrators.php
+++ b/csrest_administrators.php
@@ -36,7 +36,7 @@ class CS_REST_Administrators extends CS_REST_Wrapper_Base {
      * @param $transport The transport to use. Used for dependency injection
      * @access public
      */
-    function CS_REST_Administrators (    
+    function __construct (
     $auth_details,
     $protocol = 'https',
     $debug_level = CS_REST_LOG_NONE,
@@ -45,7 +45,7 @@ class CS_REST_Administrators extends CS_REST_Wrapper_Base {
     $serialiser = NULL,
     $transport = NULL) {
         	
-        $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
+        parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
         $this->_admins_base_route = $this->_base_route.'admins';
     }
 

--- a/csrest_campaigns.php
+++ b/csrest_campaigns.php
@@ -37,7 +37,7 @@ class CS_REST_Campaigns extends CS_REST_Wrapper_Base {
      * @param $transport The transport to use. Used for dependency injection
      * @access public
      */
-    function CS_REST_Campaigns (
+    function __construct (
     $campaign_id,
     $auth_details,
     $protocol = 'https',
@@ -47,7 +47,7 @@ class CS_REST_Campaigns extends CS_REST_Wrapper_Base {
     $serialiser = NULL,
     $transport = NULL) {
         	
-        $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
+        parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
         $this->set_campaign_id($campaign_id);
     }
 

--- a/csrest_clients.php
+++ b/csrest_clients.php
@@ -37,7 +37,7 @@ class CS_REST_Clients extends CS_REST_Wrapper_Base {
      * @param $transport The transport to use. Used for dependency injection
      * @access public
      */
-    function CS_REST_Clients(
+    function __construct(
     $client_id,
     $auth_details,
     $protocol = 'https',
@@ -47,7 +47,7 @@ class CS_REST_Clients extends CS_REST_Wrapper_Base {
     $serialiser = NULL,
     $transport = NULL) {
         	
-        $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
+        parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
         $this->set_client_id($client_id);
     }
 

--- a/csrest_lists.php
+++ b/csrest_lists.php
@@ -51,7 +51,7 @@ class CS_REST_Lists extends CS_REST_Wrapper_Base {
      * @param $transport The transport to use. Used for dependency injection
      * @access public
      */
-    function CS_REST_Lists (
+    function __construct (
     $list_id,
     $auth_details,
     $protocol = 'https',
@@ -60,8 +60,8 @@ class CS_REST_Lists extends CS_REST_Wrapper_Base {
     $log = NULL,
     $serialiser = NULL,
     $transport = NULL) {
-        	
-        $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
+
+        parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
         $this->set_list_id($list_id);
     }
 

--- a/csrest_people.php
+++ b/csrest_people.php
@@ -37,7 +37,7 @@ class CS_REST_People extends CS_REST_Wrapper_Base {
      * @param $transport The transport to use. Used for dependency injection
      * @access public
      */
-    function CS_REST_People (
+    function __construct (
     $client_id,
     $auth_details,
     $protocol = 'https',
@@ -46,8 +46,8 @@ class CS_REST_People extends CS_REST_Wrapper_Base {
     $log = NULL,
     $serialiser = NULL,
     $transport = NULL) {
-        	
-        $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
+
+        parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
         $this->set_client_id($client_id);
 
     }

--- a/csrest_segments.php
+++ b/csrest_segments.php
@@ -37,7 +37,7 @@ class CS_REST_Segments extends CS_REST_Wrapper_Base {
      * @param $transport The transport to use. Used for dependency injection
      * @access public
      */
-    function CS_REST_Segments (
+    function __construct (
     $segment_id,
     $auth_details,
     $protocol = 'https',
@@ -46,8 +46,8 @@ class CS_REST_Segments extends CS_REST_Wrapper_Base {
     $log = NULL,
     $serialiser = NULL,
     $transport = NULL) {
-            
-        $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
+
+        parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
         $this->set_segment_id($segment_id);
     }
 

--- a/csrest_subscribers.php
+++ b/csrest_subscribers.php
@@ -37,7 +37,7 @@ class CS_REST_Subscribers extends CS_REST_Wrapper_Base {
      * @param $transport The transport to use. Used for dependency injection
      * @access public
      */
-    function CS_REST_Subscribers (
+    function __construct (
     $list_id,
     $auth_details,
     $protocol = 'https',
@@ -46,8 +46,8 @@ class CS_REST_Subscribers extends CS_REST_Wrapper_Base {
     $log = NULL,
     $serialiser = NULL,
     $transport = NULL) {
-        	
-        $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
+
+        parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
         $this->set_list_id($list_id);
 
     }

--- a/csrest_templates.php
+++ b/csrest_templates.php
@@ -36,7 +36,7 @@ class CS_REST_Templates extends CS_REST_Wrapper_Base {
      * @param $transport The transport to use. Used for dependency injection
      * @access public
      */
-    function CS_REST_Templates (
+    function __construct (
     $template_id,
     $auth_details,
     $protocol = 'https',
@@ -45,8 +45,8 @@ class CS_REST_Templates extends CS_REST_Wrapper_Base {
     $log = NULL,
     $serialiser = NULL,
     $transport = NULL) {
-        	
-        $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
+
+        parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
         $this->set_template_id($template_id);
     }
 

--- a/csrest_transactional_classicemail.php
+++ b/csrest_transactional_classicemail.php
@@ -37,7 +37,7 @@ class CS_REST_Transactional_ClassicEmail extends CS_REST_Wrapper_Base {
      * @param $transport The transport to use. Used for dependency injection
      * @access public
      */
-    function CS_REST_Transactional_ClassicEmail (
+    function __construct (
     $auth_details,
     $client_id = NULL,
     $protocol = 'https',
@@ -46,7 +46,7 @@ class CS_REST_Transactional_ClassicEmail extends CS_REST_Wrapper_Base {
     $log = NULL,
     $serialiser = NULL,
     $transport = NULL) {
-        $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
+        parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
         $this->set_client($client_id);
     }
 

--- a/csrest_transactional_smartemail.php
+++ b/csrest_transactional_smartemail.php
@@ -45,7 +45,7 @@ class CS_REST_Transactional_SmartEmail extends CS_REST_Wrapper_Base {
      * @param $transport The transport to use. Used for dependency injection
      * @access public
      */
-    function CS_REST_Transactional_SmartEmail (
+    function __construct (
     $smartemail_id,
     $auth_details,
     $client_id = NULL,
@@ -55,7 +55,7 @@ class CS_REST_Transactional_SmartEmail extends CS_REST_Wrapper_Base {
     $log = NULL,
     $serialiser = NULL,
     $transport = NULL) {
-        $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
+        parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
         $this->set_client($client_id);
         $this->set_smartemail_id($smartemail_id);
     }

--- a/csrest_transactional_timeline.php
+++ b/csrest_transactional_timeline.php
@@ -37,7 +37,7 @@ class CS_REST_Transactional_Timeline extends CS_REST_Wrapper_Base {
      * @param $transport The transport to use. Used for dependency injection
      * @access public
      */
-    function CS_REST_Transactional_Timeline (
+    function __construct (
     $auth_details,
     $client_id = NULL,
     $protocol = 'https',
@@ -46,7 +46,7 @@ class CS_REST_Transactional_Timeline extends CS_REST_Wrapper_Base {
     $log = NULL,
     $serialiser = NULL,
     $transport = NULL) {
-        $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
+        parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
         $this->set_client($client_id);
     }
 

--- a/tests/class_tests/transport_test.php
+++ b/tests/class_tests/transport_test.php
@@ -26,7 +26,7 @@ class CS_REST_TestSocketTransport extends UnitTestCase {
 
         $this->transport = new CS_REST_SocketTransport($this->mock_log, $this->mock_wrapper);
         $this->partial = new PartialSocketTransport($this);
-        $this->partial->CS_REST_SocketTransport($this->mock_log, $this->mock_wrapper);
+        $this->partial->__construct($this->mock_log, $this->mock_wrapper);
     }
 
     function test_make_call_http() {


### PR DESCRIPTION
In PHP7 all PHP4 constructors are marked as deprecated. See https://wiki.php.net/rfc/remove_php4_constructors