### PR TITLE
Throw exception instead of fatal error when curl request fails

### DIFF
--- a/class/exceptions.php
+++ b/class/exceptions.php
@@ -1,0 +1,9 @@
+<?php
+
+class CurlException extends \RuntimeException
+{
+    public function __construct($curlMessage, $errorCode)
+    {
+        parent::__construct('Error making request with curl_error: ' . $curlMessage, $errorCode);
+    }
+}

--- a/class/transport.php
+++ b/class/transport.php
@@ -160,7 +160,9 @@ class CS_REST_CurlTransport extends CS_REST_BaseTransport {
         if(!$response && $response !== '') {
             $this->_log->log_message('Error making request with curl_error: '.curl_errno($ch),
                 get_class($this), CS_REST_LOG_ERROR);
-            trigger_error('Error making request with curl_error: '.curl_error($ch), E_USER_ERROR);
+
+            require_once dirname(__FILE__).'/exceptions.php';
+            throw new CurlException(curl_error($ch), curl_errno($ch));
         }
         
         list( $headers, $result ) = $this->split_and_inflate($response, $inflate_response);


### PR DESCRIPTION
This enables the user to catch this exception, and gracefully handle this failing.