### PR TITLE
Add Constructor for CS_REST_DoNothingSerialiser

### DIFF
--- a/class/serialisation.php
+++ b/class/serialisation.php
@@ -47,6 +47,7 @@ class CS_REST_BaseSerialiser {
 }
 
 class CS_REST_DoNothingSerialiser extends CS_REST_BaseSerialiser {
+    function __construct() {}
     function CS_REST_DoNothingSerialiser() {}
     function get_type() { return 'do_nothing'; }
     function serialise($data) { return $data; }


### PR DESCRIPTION
With the removal of the PHP 4 constructors, the constructor for **CS_REST_DoNothingSerialiser** in favor of the parent constructor in CS_REST_BaseSerialiser. However this caused an error as the previous constructor for  CS_REST_DoNothingSerialiser had no parameters. A new constructor for CS_REST_DoNothingSerialiser has been added.