### PR TITLE
When Log is NULL, will fail to construct

### DIFF
--- a/class/serialisation.php
+++ b/class/serialisation.php
@@ -16,7 +16,7 @@ class CS_REST_BaseSerialiser {
 
     var $_log;
     
-    function __construct($log) {
+    function __construct($log = null) {
         $this->_log = $log;
     }
     


### PR DESCRIPTION
I am using this API as a Symfony bundle and the way things are put together in csrest_general.php at line 62:

$wrap = new CS_REST_Wrapper_Base(
NULL, 'https', CS_REST_LOG_NONE, CS_HOST, NULL,
new CS_REST_DoNothingSerialiser(), NULL);

The BaseSerialiser would always fail