### PR TITLE
Update test suite for PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ dist: trusty
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 before_script: composer install --dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
     cd tests && php all_tests.php && cd ..
     ```
 
-    The [Travis CI build](https://travis-ci.org/campaignmonitor/createsend-php) runs on PHP `5.3` and `5.4`.
+    The [Travis CI build](https://travis-ci.org/campaignmonitor/createsend-php) runs on PHP `5.3`, `5.4`, `5.5`, `5.6`, `7.0` and `hhvm`.
 
 5. It should go without saying, but do not increment the version number in your commits.
 6. [Submit a pull request](https://help.github.com/articles/using-pull-requests).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
     cd tests && php all_tests.php && cd ..
     ```
 
-    The [Travis CI build](https://travis-ci.org/campaignmonitor/createsend-php) runs on PHP `5.3`, `5.4`, `5.5`, `5.6`, `7.0` and `hhvm`.
+    The [Travis CI build](https://travis-ci.org/campaignmonitor/createsend-php) runs on PHP `5.4`, `5.5`, `5.6`, `7.0`, `7.1` and `hhvm`.
 
 5. It should go without saying, but do not increment the version number in your commits.
 6. [Submit a pull request](https://help.github.com/articles/using-pull-requests).

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "simpletest/simpletest": "~1.1.3"
+        "simpletest/simpletest": "~1.1.7"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "simpletest/simpletest": "~1.1.7"

--- a/composer.lock
+++ b/composer.lock
@@ -1,57 +1,94 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "eccad7521596b5fe0d81af51ab2f16a1",
-    "packages": [
-
-    ],
+    "hash": "c61f5fcdb8272edfd2286cd3c1297c59",
+    "content-hash": "fd72e6a1e24eb969c3935a67d6f533dd",
+    "packages": [],
     "packages-dev": [
         {
             "name": "simpletest/simpletest",
-            "version": "1.1.3",
+            "version": "v1.1.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/simpletest/simpletest",
-                "reference": "1.1.3"
+                "url": "https://github.com/simpletest/simpletest.git",
+                "reference": "2f8c466c114bdb9c11028a0c3e6d1380ae6a18dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/simpletest/simpletest/zipball/1.1.3",
-                "reference": "1.1.3",
+                "url": "https://api.github.com/repos/simpletest/simpletest/zipball/2f8c466c114bdb9c11028a0c3e6d1380ae6a18dc",
+                "reference": "2f8c466c114bdb9c11028a0c3e6d1380ae6a18dc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.0.5"
             },
+            "replace": {
+                "lastcraft/simpletest": "self.version",
+                "vierbergenlars/simpletest": "self.version"
+            },
             "type": "library",
+            "autoload": {
+                "classmap": [
+                    "."
+                ]
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-2.0+"
             ],
             "authors": [
                 {
+                    "name": "Lars Vierbergen",
+                    "email": "vierbergenlars@gmail.com"
+                },
+                {
+                    "name": "Lachlan Donald",
+                    "email": "lachlan@ljd.cc"
+                },
+                {
                     "name": "Marcus Baker",
-                    "email": "marcus@lastcraft.com"
+                    "email": "marcus@lastcraft.com",
+                    "role": "Original project lead"
+                },
+                {
+                    "name": "Jason Sweat",
+                    "role": "Original developer"
+                },
+                {
+                    "name": "Travis Swicegood",
+                    "role": "Original developer"
+                },
+                {
+                    "name": "Perrick Penet",
+                    "role": "Original developer"
+                },
+                {
+                    "name": "Edward Z. Yang",
+                    "role": "Original developer"
                 }
             ],
             "description": "Unit testing, mock objects and web testing framework for PHP built around test cases.",
             "homepage": "http://simpletest.org/",
-            "time": "2012-06-11 22:22:54"
+            "keywords": [
+                "SimpleTest",
+                "code-coverage",
+                "selenium",
+                "testing",
+                "unit-test"
+            ],
+            "time": "2015-09-21 18:19:52"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.3.0"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c61f5fcdb8272edfd2286cd3c1297c59",
-    "content-hash": "fd72e6a1e24eb969c3935a67d6f533dd",
+    "hash": "0a1730e0be589c55a51aa92f146da77b",
+    "content-hash": "26fecab2d6ff4273664cc3afab6660d9",
     "packages": [],
     "packages-dev": [
         {
@@ -88,7 +88,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0"
     },
     "platform-dev": []
 }

--- a/tests/all_tests.php
+++ b/tests/all_tests.php
@@ -4,8 +4,8 @@ require_once __DIR__.'/../vendor/simpletest/simpletest/autorun.php';
 require_once __DIR__.'/../vendor/simpletest/simpletest/mock_objects.php';
 
 class AllTests extends TestSuite {
-    function AllTests() {
-        $this->TestSuite('All Tests');
+    function __construct() {
+        parent::__construct('All Tests');
         $this->addFile('class_tests/transport_test.php');
         $this->addFile('class_tests/response_tests.php');
         $this->addFile('csrest_test.php');

--- a/tests/csrest_test.php
+++ b/tests/csrest_test.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__.'/../vendor/autoload.php';
 require_once __DIR__.'/../vendor/simpletest/simpletest/autorun.php';
+require_once(__DIR__.'/../vendor/simpletest/simpletest/mock_objects.php');
 
 @Mock::generate('CS_REST_Log');
 @Mock::generate('CS_REST_NativeJsonSerialiser');


### PR DESCRIPTION
This PR fix the testsuite for PHP7.

Travis CI says that the build succeeds, but looking at the job here: https://travis-ci.org/campaignmonitor/createsend-php/jobs/232310201 doesn't seem so.

This is the result of the build: https://travis-ci.org/matjack1/createsend-php/builds/240026279

Plus, I dropped support for PHP 5.3 and added 7.1, as 5.3 is not available anymore on Trusty, which instead is needed for HHVM. If you prefer to support 5.3 and drop HHVM I can change that, but supporting both is more complicated.