### PR TITLE
Suppress class_exists errors

### DIFF
--- a/class/base_classes.php
+++ b/class/base_classes.php
@@ -16,7 +16,7 @@ defined('CS_REST_WEBHOOK_FORMAT_XML') or define('CS_REST_WEBHOOK_FORMAT_XML', 'x
  * @author tobyb
  *
  */
-if (!class_exists('CS_REST_Wrapper_Result')) {
+if (!@class_exists('CS_REST_Wrapper_Result')) {
     class CS_REST_Wrapper_Result {
         /**
          * The deserialised result of the API call
@@ -52,7 +52,7 @@ if (!class_exists('CS_REST_Wrapper_Result')) {
  * @author tobyb
  *
  */
-if (!class_exists('CS_REST_Wrapper_Base')) {
+if (!@class_exists('CS_REST_Wrapper_Base')) {
     class CS_REST_Wrapper_Base {
         /**
          * The protocol to use while accessing the api

--- a/class/exceptions.php
+++ b/class/exceptions.php
@@ -1,5 +1,5 @@
 <?php
-if (!class_exists('CurlException')) {
+if (!@class_exists('CurlException')) {
 	class CurlException extends \RuntimeException
 	{
 	    public function __construct($curlMessage, $errorCode)

--- a/class/log.php
+++ b/class/log.php
@@ -4,7 +4,7 @@ defined('CS_REST_LOG_WARNING') or define('CS_REST_LOG_WARNING', 500);
 defined('CS_REST_LOG_ERROR') or define('CS_REST_LOG_ERROR', 250);
 defined('CS_REST_LOG_NONE') or define('CS_REST_LOG_NONE', 0);
 
-if (!class_exists('CS_REST_Log')) {
+if (!@class_exists('CS_REST_Log')) {
 	class CS_REST_Log {
 	    var $_level;
 

--- a/class/serialisation.php
+++ b/class/serialisation.php
@@ -1,32 +1,32 @@
 <?php
 
-if (!class_exists('Services_JSON', false)) {
+if (!@class_exists('Services_JSON')) {
     require_once dirname(__FILE__).'/services_json.php';
 }
 
 if(!function_exists("CS_REST_SERIALISATION_get_available")) {
-    function CS_REST_SERIALISATION_get_available($log) { 
+    function CS_REST_SERIALISATION_get_available($log) {
         $log->log_message('Getting serialiser', __FUNCTION__, CS_REST_LOG_VERBOSE);
         if(function_exists('json_decode') && function_exists('json_encode')) {
             return new CS_REST_NativeJsonSerialiser($log);
         } else {
             return new CS_REST_ServicesJsonSerialiser($log);
-        }    
+        }
     }
 }
 
-if (!class_exists('CS_REST_BaseSerialiser')) {
+if (!@class_exists('CS_REST_BaseSerialiser')) {
     class CS_REST_BaseSerialiser {
 
         var $_log;
-        
+
         function __construct($log) {
             $this->_log = $log;
         }
-        
+
         /**
-         * Recursively ensures that all data values are utf-8 encoded. 
-         * @param array $data All values of this array are checked for utf-8 encoding. 
+         * Recursively ensures that all data values are utf-8 encoded.
+         * @param array $data All values of this array are checked for utf-8 encoding.
          */
         function check_encoding($data) {
 
@@ -36,22 +36,22 @@ if (!class_exists('CS_REST_BaseSerialiser')) {
                     $data[$k] = $this->check_encoding($v);
                 // Otherwise if the element is a string then we need to check the encoding
                 } else if(is_string($v)) {
-                    if((function_exists('mb_detect_encoding') && mb_detect_encoding($v) !== 'UTF-8') || 
+                    if((function_exists('mb_detect_encoding') && mb_detect_encoding($v) !== 'UTF-8') ||
                        (function_exists('mb_check_encoding') && !mb_check_encoding($v, 'UTF-8'))) {
                         // The string is using some other encoding, make sure we utf-8 encode
-                        $v = utf8_encode($v);       
+                        $v = utf8_encode($v);
                     }
-                    
+
                     $data[$k] = $v;
                 }
             }
-                  
+
             return $data;
-        }    
+        }
     }
 }
 
-if (!class_exists('CS_REST_DoNothingSerialiser')) {
+if (!@class_exists('CS_REST_DoNothingSerialiser')) {
     class CS_REST_DoNothingSerialiser extends CS_REST_BaseSerialiser {
     function __construct() {}
         function get_type() { return 'do_nothing'; }
@@ -64,13 +64,13 @@ if (!class_exists('CS_REST_DoNothingSerialiser')) {
     }
 }
 
-if (!class_exists('CS_REST_NativeJsonSerialiser')) {
+if (!@class_exists('CS_REST_NativeJsonSerialiser')) {
     class CS_REST_NativeJsonSerialiser extends CS_REST_BaseSerialiser {
 
         function get_format() {
             return 'json';
         }
-        
+
         function get_type() {
             return 'native';
         }
@@ -86,9 +86,9 @@ if (!class_exists('CS_REST_NativeJsonSerialiser')) {
             return $this->strip_surrounding_quotes(is_null($data) ? $text : $data);
         }
 
-        /** 
-         * We've had sporadic reports of people getting ID's from create routes with the surrounding quotes present. 
-         * There is no case where these should be present. Just get rid of it. 
+        /**
+         * We've had sporadic reports of people getting ID's from create routes with the surrounding quotes present.
+         * There is no case where these should be present. Just get rid of it.
          */
         function strip_surrounding_quotes($data) {
             if(is_string($data)) {
@@ -100,11 +100,11 @@ if (!class_exists('CS_REST_NativeJsonSerialiser')) {
     }
 }
 
-if (!class_exists('CS_REST_ServicesJsonSerialiser')) {
+if (!@class_exists('CS_REST_ServicesJsonSerialiser')) {
     class CS_REST_ServicesJsonSerialiser extends CS_REST_BaseSerialiser {
-        
+
         var $_serialiser;
-        
+
         function __construct($log) {
             parent::__construct($log);
             $this->_serialiser = new Services_JSON();
@@ -117,19 +117,19 @@ if (!class_exists('CS_REST_ServicesJsonSerialiser')) {
         function get_format() {
             return 'json';
         }
-        
+
         function get_type() {
             return 'services_json';
         }
-        
+
         function serialise($data) {
         	if(is_null($data) || $data == '') return '';
             return $this->_serialiser->encode($this->check_encoding($data));
         }
-        
+
         function deserialise($text) {
             $data = $this->_serialiser->decode($text);
-            
+
             return is_null($data) ? $text : $data;
         }
     }

--- a/class/services_json.php
+++ b/class/services_json.php
@@ -111,7 +111,7 @@ defined('SERVICES_JSON_SUPPRESS_ERRORS') or define('SERVICES_JSON_SUPPRESS_ERROR
  * $value = $json->decode($input);
  * </code>
  */
-if (!class_exists('Services_JSON')) {
+if (!@class_exists('Services_JSON')) {
     class Services_JSON
     {
        /**
@@ -666,7 +666,7 @@ if (!class_exists('Services_JSON')) {
                                     // element in an associative array,
                                     // for now
                                     $parts = array();
-                                    
+
                                     if (preg_match('/^\s*(["\'].*[^\\\]["\'])\s*:\s*(\S.*),?$/Uis', $slice, $parts)) {
                                         // "name":value pair
                                         $key = $this->decode($parts[1]);
@@ -759,7 +759,7 @@ if (!class_exists('Services_JSON')) {
                     }
             }
         }
-        
+
         function isError($data, $code = null)
         {
             if (is_object($data) && (get_class($data) == 'services_json_error' ||
@@ -772,7 +772,7 @@ if (!class_exists('Services_JSON')) {
     }
 }
 
-if (!class_exists('Services_JSON_Error')) {
+if (!@class_exists('Services_JSON_Error')) {
     class Services_JSON_Error
     {
         function __construct($message = 'unknown error', $code = null,
@@ -782,5 +782,5 @@ if (!class_exists('Services_JSON_Error')) {
         }
     }
 }
- 
+
 ?>

--- a/class/transport.php
+++ b/class/transport.php
@@ -11,18 +11,18 @@ if (false === defined('CS_REST_CALL_TIMEOUT')) {
     define('CS_REST_CALL_TIMEOUT', 10);
 }
 
-if(!function_exists("CS_REST_TRANSPORT_get_available")) {    
+if(!function_exists("CS_REST_TRANSPORT_get_available")) {
     function CS_REST_TRANSPORT_get_available($requires_ssl, $log) {
         if(function_exists('curl_init') && function_exists('curl_exec')) {
             return new CS_REST_CurlTransport($log);
         } else if(CS_REST_TRANSPORT_can_use_raw_socket($requires_ssl)) {
             return new CS_REST_SocketTransport($log);
-        } else { 
+        } else {
             $log->log_message('No transport is available', __FUNCTION__, CS_REST_LOG_ERROR);
             trigger_error('No transport is available.'.
                 ($requires_ssl ? ' Try using non-secure (http) mode or ' : ' Please ').
                 'ensure the cURL extension is loaded', E_USER_ERROR);
-        }    
+        }
     }
 }
 
@@ -40,30 +40,30 @@ if(!function_exists("CS_REST_TRANSPORT_can_use_raw_socket")) {
     }
 }
 
-if (!class_exists('CS_REST_BaseTransport')) {
+if (!@class_exists('CS_REST_BaseTransport')) {
     class CS_REST_BaseTransport {
-        
+
         var $_log;
         
         function __construct($log) {
             $this->_log = $log;
         }
-        
-        function split_and_inflate($response, $may_be_compressed) {        
+
+        function split_and_inflate($response, $may_be_compressed) {
             $ra = explode("\r\n\r\n", $response);
-            
+
             $result = array_pop($ra);
             $headers = array_pop($ra);
-            
-            if($may_be_compressed && preg_match('/^Content-Encoding:\s+gzip\s+$/im', $headers)) {        
+
+            if($may_be_compressed && preg_match('/^Content-Encoding:\s+gzip\s+$/im', $headers)) {
                 $original_length = strlen($response);
                 $result = gzinflate(substr($result, 10, -8));
-        
+
                 $this->_log->log_message('Inflated gzipped response: '.$original_length.' bytes ->'.
                     strlen($result).' bytes', get_class(), CS_REST_LOG_VERBOSE);
             }
-            
-            return array($headers, $result); 
+
+            return array($headers, $result);
         }
 
     }
@@ -74,14 +74,14 @@ if (!class_exists('CS_REST_BaseTransport')) {
  * @author tobyb
  * @since 1.0
  */
-if (!class_exists('CS_REST_CurlTransport')) {
+if (!@class_exists('CS_REST_CurlTransport')) {
     class CS_REST_CurlTransport extends CS_REST_BaseTransport {
 
         var $_curl_zlib;
 
         function __construct($log) {
             parent::__construct($log);
-            
+
             $curl_version = curl_version();
             $this->_curl_zlib = isset($curl_version['libz_version']);
         }
@@ -101,7 +101,7 @@ if (!class_exists('CS_REST_CurlTransport')) {
             curl_setopt($ch, CURLOPT_HEADER, true);
             $headers = array();
             $headers[] = 'Content-Type: '.$call_options['contentType'];
-            
+
 
             if (array_key_exists('authdetails', $call_options) &&
                 isset($call_options['authdetails'])) {
@@ -135,7 +135,7 @@ if (!class_exists('CS_REST_CurlTransport')) {
                 $headers[] = 'Accept-Encoding: gzip';
                 $inflate_response = true;
             }
-            
+
             if($call_options['protocol'] === 'https') {
                 curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
                 curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
@@ -159,7 +159,7 @@ if (!class_exists('CS_REST_CurlTransport')) {
                     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, CS_REST_DELETE);
                     break;
             }
-            
+
             if(count($headers) > 0) {
                 curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
             }
@@ -173,13 +173,13 @@ if (!class_exists('CS_REST_CurlTransport')) {
                 require_once dirname(__FILE__).'/exceptions.php';
                 throw new CurlException(curl_error($ch), curl_errno($ch));
             }
-            
+
             list( $headers, $result ) = $this->split_and_inflate($response, $inflate_response);
-            
+
             $this->_log->log_message('API Call Info for '.$call_options['method'].' '.
             curl_getinfo($ch, CURLINFO_EFFECTIVE_URL).': '.curl_getinfo($ch, CURLINFO_SIZE_UPLOAD).
     		    ' bytes uploaded. '.curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD).' bytes downloaded'.
-    		    ' Total time (seconds): '.curl_getinfo($ch, CURLINFO_TOTAL_TIME), 
+    		    ' Total time (seconds): '.curl_getinfo($ch, CURLINFO_TOTAL_TIME),
             get_class($this), CS_REST_LOG_VERBOSE);
 
             $result = array(
@@ -194,7 +194,7 @@ if (!class_exists('CS_REST_CurlTransport')) {
     }
 }
 
-if (!class_exists('CS_REST_SocketWrapper')) {
+if (!@class_exists('CS_REST_SocketWrapper')) {
     class CS_REST_SocketWrapper {
         var $socket;
 
@@ -228,7 +228,7 @@ if (!class_exists('CS_REST_SocketWrapper')) {
     }
 }
 
-if (!class_exists('CS_REST_SocketTransport')) {
+if (!@class_exists('CS_REST_SocketTransport')) {
     class CS_REST_SocketTransport extends CS_REST_BaseTransport {
 
         var $_socket_wrapper;
@@ -270,25 +270,25 @@ if (!class_exists('CS_REST_SocketTransport')) {
 
             if($this->_socket_wrapper->open($domain, $port)) {
                 $inflate_response = function_exists('gzinflate');
-                
+
                 $request = $this->_build_request($call_options, $host, $path, $inflate_response);
                 $this->_log->log_message('Sending <pre>'.$request.'</pre> down the socket',
                 get_class($this), CS_REST_LOG_VERBOSE);
-                 
+
                 $this->_socket_wrapper->write($request);
                 $response = $this->_socket_wrapper->read();
                 $this->_socket_wrapper->close();
-                	
+
                 $this->_log->log_message('API Call Info for '.$call_options['method'].' '.
                 $call_options['route'].': '.strlen($request).
-    	            ' bytes uploaded. '.strlen($response).' bytes downloaded', 
+    	            ' bytes uploaded. '.strlen($response).' bytes downloaded',
                 get_class($this), CS_REST_LOG_VERBOSE);
-                	
+
                 list( $headers, $result ) = $this->split_and_inflate($response, $inflate_response);
-                    
+
                 $this->_log->log_message('Received headers <pre>'.$headers.'</pre>',
                     get_class($this), CS_REST_LOG_VERBOSE);
-                	
+
                 return array(
     			    'code' => $this->_get_status_code($headers),
     			    'response' => trim($result)
@@ -305,7 +305,7 @@ if (!class_exists('CS_REST_SocketTransport')) {
 
             $this->_log->log_message('Failed to get HTTP status code from request headers <pre>'.$headers.'</pre>',
                 get_class($this), CS_REST_LOG_ERROR);
-            trigger_error('Failed to get HTTP status code from request', E_USER_ERROR);        
+            trigger_error('Failed to get HTTP status code from request', E_USER_ERROR);
         }
 
         function _build_request($call_options, $host, $path, $accept_gzip) {
@@ -337,7 +337,7 @@ if (!class_exists('CS_REST_SocketTransport')) {
 
             if($accept_gzip) {
                 $request .=
-    "Accept-Encoding: gzip\n";           
+    "Accept-Encoding: gzip\n";
             }
 
             if(isset($call_options['data'])) {

--- a/csrest_administrators.php
+++ b/csrest_administrators.php
@@ -8,7 +8,7 @@ require_once dirname(__FILE__).'/class/base_classes.php';
  * @author pauld
  *
  */
-if (!class_exists('CS_REST_Administrators')) {
+if (!@class_exists('CS_REST_Administrators')) {
     class CS_REST_Administrators extends CS_REST_Wrapper_Base {
 
         /**
@@ -45,7 +45,7 @@ if (!class_exists('CS_REST_Administrators')) {
         $log = NULL,
         $serialiser = NULL,
         $transport = NULL) {
-            	
+
             parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
             $this->_admins_base_route = $this->_base_route.'admins';
         }
@@ -68,7 +68,7 @@ if (!class_exists('CS_REST_Administrators')) {
         /**
          * Updates details for an existing administrator associated with the current account
     	 * @param string $email The email address of the administrator to be updated
-         * @param array $admin The updated administrator details to use for the update. 
+         * @param array $admin The updated administrator details to use for the update.
          *     This array should be of the form
          *     array (
          *         'EmailAddress' => The new email address

--- a/csrest_campaigns.php
+++ b/csrest_campaigns.php
@@ -8,7 +8,7 @@ require_once dirname(__FILE__).'/class/base_classes.php';
  * @author tobyb
  *
  */
-if (!class_exists('CS_REST_Campaigns')) {
+if (!@class_exists('CS_REST_Campaigns')) {
     class CS_REST_Campaigns extends CS_REST_Wrapper_Base {
 
         /**
@@ -47,7 +47,7 @@ if (!class_exists('CS_REST_Campaigns')) {
         $log = NULL,
         $serialiser = NULL,
         $transport = NULL) {
-            	
+
             parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
             $this->set_campaign_id($campaign_id);
         }
@@ -112,20 +112,20 @@ if (!class_exists('CS_REST_Campaigns')) {
         }
 
         /**
-         * Sends a preview of an existing campaign to the specified recipients. 
-         * @param array<string> $recipients The recipients to send the preview to. 
+         * Sends a preview of an existing campaign to the specified recipients.
+         * @param array<string> $recipients The recipients to send the preview to.
          * @param string $personalize How to personalize the campaign content. Valid options are:
          *     'Random': Choose a random campaign recipient and use their personalisation data
          *     'Fallback': Use the fallback terms specified in the campaign content
          * @access public
          * @return CS_REST_Wrapper_Result A successful response will be empty
          */
-        function send_preview($recipients, $personalize = 'Random') { 
+        function send_preview($recipients, $personalize = 'Random') {
             $preview_data = array(
                 'PreviewRecipients' => $recipients,
                 'Personalize' => $personalize
             );
-            
+
             return $this->post_request($this->_campaigns_base_route.'sendpreview.json', $preview_data);
         }
 
@@ -146,7 +146,7 @@ if (!class_exists('CS_REST_Campaigns')) {
         }
 
         /**
-         * Unschedules the campaign, moving it back into the drafts. If the campaign has been sent or is   
+         * Unschedules the campaign, moving it back into the drafts. If the campaign has been sent or is
          * in the process of sending, this api request will fail.
          * @access public
          * @return CS_REST_Wrapper_Result A successful response will be empty
@@ -188,9 +188,9 @@ if (!class_exists('CS_REST_Campaigns')) {
          *     )
          * }
          */
-        function get_recipients($page_number = NULL, $page_size = NULL, $order_field = NULL, 
-            $order_direction = NULL) {            
-            return $this->get_request_paged($this->_campaigns_base_route.'recipients.json', $page_number, 
+        function get_recipients($page_number = NULL, $page_size = NULL, $order_field = NULL,
+            $order_direction = NULL) {
+            return $this->get_request_paged($this->_campaigns_base_route.'recipients.json', $page_number,
                 $page_size, $order_field, $order_direction, '?');
         }
 
@@ -223,7 +223,7 @@ if (!class_exists('CS_REST_Campaigns')) {
          * }
          * )
          */
-        function get_bounces($since = '', $page_number = NULL, $page_size = NULL, $order_field = NULL, 
+        function get_bounces($since = '', $page_number = NULL, $page_size = NULL, $order_field = NULL,
             $order_direction = NULL) {
             return $this->get_request_paged($this->_campaigns_base_route.'bounces.json?date='.urlencode($since),
                 $page_number, $page_size, $order_field, $order_direction);
@@ -239,7 +239,7 @@ if (!class_exists('CS_REST_Campaigns')) {
          *             'ListID' => The list id
          *             'Name' => The list name
          *         }
-         *     ), 
+         *     ),
          *     'Segments' => array(
          *         {
          *             'ListID' => The list id of the segment
@@ -327,9 +327,9 @@ if (!class_exists('CS_REST_Campaigns')) {
          *     )
          * }
          */
-        function get_opens($since = '', $page_number = NULL, $page_size = NULL, $order_field = NULL, 
+        function get_opens($since = '', $page_number = NULL, $page_size = NULL, $order_field = NULL,
             $order_direction = NULL) {
-            return $this->get_request_paged($this->_campaigns_base_route.'opens.json?date='.urlencode($since), 
+            return $this->get_request_paged($this->_campaigns_base_route.'opens.json?date='.urlencode($since),
                 $page_number, $page_size, $order_field, $order_direction);
         }
 
@@ -367,9 +367,9 @@ if (!class_exists('CS_REST_Campaigns')) {
          *     )
          * }
          */
-        function get_clicks($since = '', $page_number = NULL, $page_size = NULL, $order_field = NULL, 
+        function get_clicks($since = '', $page_number = NULL, $page_size = NULL, $order_field = NULL,
             $order_direction = NULL) {
-            return $this->get_request_paged($this->_campaigns_base_route.'clicks.json?date='.urlencode($since), 
+            return $this->get_request_paged($this->_campaigns_base_route.'clicks.json?date='.urlencode($since),
                 $page_number, $page_size, $order_field, $order_direction);
         }
 
@@ -400,9 +400,9 @@ if (!class_exists('CS_REST_Campaigns')) {
          *     )
          * }
          */
-        function get_unsubscribes($since = '', $page_number = NULL, $page_size = NULL, $order_field = NULL, 
+        function get_unsubscribes($since = '', $page_number = NULL, $page_size = NULL, $order_field = NULL,
             $order_direction = NULL) {
-            return $this->get_request_paged($this->_campaigns_base_route.'unsubscribes.json?date='.urlencode($since), 
+            return $this->get_request_paged($this->_campaigns_base_route.'unsubscribes.json?date='.urlencode($since),
                 $page_number, $page_size, $order_field, $order_direction);
         }
 
@@ -432,9 +432,9 @@ if (!class_exists('CS_REST_Campaigns')) {
          *     )
          * }
          */
-        function get_spam($since = '', $page_number = NULL, $page_size = NULL, $order_field = NULL, 
+        function get_spam($since = '', $page_number = NULL, $page_size = NULL, $order_field = NULL,
             $order_direction = NULL) {
-            return $this->get_request_paged($this->_campaigns_base_route.'spam.json?date='.urlencode($since), 
+            return $this->get_request_paged($this->_campaigns_base_route.'spam.json?date='.urlencode($since),
                 $page_number, $page_size, $order_field, $order_direction);
         }
     }

--- a/csrest_clients.php
+++ b/csrest_clients.php
@@ -8,7 +8,7 @@ require_once dirname(__FILE__).'/class/base_classes.php';
  * @author tobyb
  *
  */
-if (!class_exists('CS_REST_Clients')) {
+if (!@class_exists('CS_REST_Clients')) {
     class CS_REST_Clients extends CS_REST_Wrapper_Base {
 
         /**
@@ -47,7 +47,7 @@ if (!class_exists('CS_REST_Clients')) {
         $log = NULL,
         $serialiser = NULL,
         $transport = NULL) {
-            	
+
             parent::__construct($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
             $this->set_client_id($client_id);
         }
@@ -161,7 +161,7 @@ if (!class_exists('CS_REST_Clients')) {
          * )
          */
         function get_lists_for_email($email_address) {
-            return $this->get_request($this->_clients_base_route . 
+            return $this->get_request($this->_clients_base_route .
               'listsforemail.json?email='.urlencode($email_address));
         }
 
@@ -206,10 +206,10 @@ if (!class_exists('CS_REST_Clients')) {
          *     )
          * }
          */
-        function get_suppressionlist($page_number = NULL, $page_size = NULL, $order_field = NULL, 
+        function get_suppressionlist($page_number = NULL, $page_size = NULL, $order_field = NULL,
             $order_direction = NULL) {
-                
-            return $this->get_request_paged($this->_clients_base_route.'suppressionlist.json', 
+
+            return $this->get_request_paged($this->_clients_base_route.'suppressionlist.json',
                 $page_number, $page_size, $order_field, $order_direction, '?');
         }
 
@@ -256,7 +256,7 @@ if (!class_exists('CS_REST_Clients')) {
          * @return CS_REST_Wrapper_Result A successful response will be an object of the form
          * {
          *     'ApiKey' => The clients API Key, THIS IS NOT THE CLIENT ID
-         *     'BasicDetails' => 
+         *     'BasicDetails' =>
          *     {
          *         'ClientID' => The id of the client
          *         'CompanyName' => The company name of the client
@@ -287,7 +287,7 @@ if (!class_exists('CS_REST_Clients')) {
          *         'MarkupOnDesignSpamTest' => The markup applied per design and spam test
          *         'Currency' => The currency fees are paid in
          *         'ClientPays' => Whether client client pays for themselves
-         *     }     
+         *     }
          * }
          */
         function get() {
@@ -388,7 +388,7 @@ if (!class_exists('CS_REST_Clients')) {
 
         /**
          * Transfer credits to or from this client.
-         * 
+         *
          * @param array $transfer_data Details for the credit transfer. This array
          *   should be of the form:
          *     array(
@@ -418,7 +418,7 @@ if (!class_exists('CS_REST_Clients')) {
 
         /**
          * returns the people associated with this client.
-         * @return CS_REST_Wrapper_Result A successful response will be an object of the form 
+         * @return CS_REST_Wrapper_Result A successful response will be an object of the form
          *     array({
          *     		'EmailAddress' => the email address of the person
          *     		'Name' => the name of the person
@@ -428,8 +428,8 @@ if (!class_exists('CS_REST_Clients')) {
          */
         function get_people() {
         	return $this->get_request($this->_clients_base_route.'people.json');
-        } 
-        
+        }
+
         /**
          * retrieves the email address of the primary contact for this client
          * @return CS_REST_Wrapper_Result a successful response will be an array in the form:
@@ -438,7 +438,7 @@ if (!class_exists('CS_REST_Clients')) {
         function get_primary_contact() {
         	return $this->get_request($this->_clients_base_route.'primarycontact.json');
         }
-        
+
         /**
          * assigns the primary contact for this client to the person with the specified email address
          * @param string $emailAddress the email address of the person designated to be the primary contact

--- a/csrest_events.php
+++ b/csrest_events.php
@@ -6,7 +6,7 @@ require_once dirname(__FILE__).'/class/base_classes.php';
  * @author cameronn
  *
  */
-if (!class_exists('CS_REST_Events')) {
+if (!@class_exists('CS_REST_Events')) {
     class CS_REST_Events extends CS_REST_Wrapper_Base {
 
         /**
@@ -67,8 +67,8 @@ if (!class_exists('CS_REST_Events')) {
         /**
          * Tracks an event
          * @param string $email required email in the form "user@example.com"
-         * 
-         * @param string $event_name. Name to group events by for reporting max length 1000 
+         *
+         * @param string $event_name. Name to group events by for reporting max length 1000
          *    For example "Page View", "Order confirmation"
          *
          * @param array $data optional. Event payload.
@@ -105,16 +105,15 @@ if (!class_exists('CS_REST_Events')) {
             if (strlen($event_name) > 1000 ) {
                 trigger_error('$event_name needs to be shorter, max length is 1000 character');
                 return new CS_REST_Wrapper_Result(null, 400);
-            }   
+            }
             if (isset($data)) {
                 if (!is_array($data)){
                 trigger_error('$data needs to be a valid array');
                 return new CS_REST_Wrapper_Result(null, 400);
-                } 
+                }
             }
             $payload = array('ContactID' => array('Email' => $email), 'EventName' => $event_name, 'Data' => $data);
             return $this->post_request($this->_events_base_route. 'track', $payload);
         }
     }
 }
-

--- a/csrest_general.php
+++ b/csrest_general.php
@@ -7,7 +7,7 @@ require_once dirname(__FILE__).'/class/base_classes.php';
  * @author tobyb
  *
  */
-if (!class_exists('CS_REST_General')) {
+if (!@class_exists('CS_REST_General')) {
     class CS_REST_General extends CS_REST_Wrapper_Base {
 
         /**
@@ -94,7 +94,7 @@ if (!class_exists('CS_REST_General')) {
             $log = NULL,
             $serialiser = NULL,
             $transport = NULL) {
-            $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);        
+            $this->CS_REST_Wrapper_Base($auth_details, $protocol, $debug_level, $host, $log, $serialiser, $transport);
         }
 
         /**
@@ -171,7 +171,7 @@ if (!class_exists('CS_REST_General')) {
         function get_administrators() {
         	return $this->get_request($this->_base_route.'admins.json');
         }
-        
+
         /**
          * Retrieves the email address of the primary contact for this account
          * @return CS_REST_Wrapper_Result a successful response will be an array in the form:

--- a/csrest_lists.php
+++ b/csrest_lists.php
@@ -22,7 +22,7 @@ defined('CS_REST_LIST_UNSUBSCRIBE_SETTING_ONLY_THIS_LIST') or define('CS_REST_LI
  * @author tobyb
  *
  */
-if (!class_exists('CS_REST_Lists')) {
+if (!@class_exists('CS_REST_Lists')) {
     class CS_REST_Lists extends CS_REST_Wrapper_Base {
 
         /**
@@ -153,7 +153,7 @@ if (!class_exists('CS_REST_Lists')) {
          *           center.
          *     )
          * @access public
-         * @return CS_REST_Wrapper_Result A successful response will be the 
+         * @return CS_REST_Wrapper_Result A successful response will be the
          * personalisation tag of the newly created custom field
          */
         function create_custom_field($custom_field_details) {
@@ -193,8 +193,8 @@ if (!class_exists('CS_REST_Lists')) {
                 'KeepExistingOptions' => $keep_existing,
                 'Options' => $new_options
             );
-            
-            return $this->put_request($this->_lists_base_route.'customfields/'.rawurlencode($key).'/options.json', 
+
+            return $this->put_request($this->_lists_base_route.'customfields/'.rawurlencode($key).'/options.json',
                 $options);
         }
 
@@ -284,10 +284,10 @@ if (!class_exists('CS_REST_Lists')) {
          *     )
          * }
          */
-        function get_active_subscribers($added_since = '', $page_number = NULL, 
+        function get_active_subscribers($added_since = '', $page_number = NULL,
             $page_size = NULL, $order_field = NULL, $order_direction = NULL) {
-                
-            return $this->get_request_paged($this->_lists_base_route.'active.json?date='.urlencode($added_since), 
+
+            return $this->get_request_paged($this->_lists_base_route.'active.json?date='.urlencode($added_since),
                 $page_number, $page_size, $order_field, $order_direction);
         }
 
@@ -324,10 +324,10 @@ if (!class_exists('CS_REST_Lists')) {
          *     )
          * }
          */
-        function get_unconfirmed_subscribers($added_since = '', $page_number = NULL, 
+        function get_unconfirmed_subscribers($added_since = '', $page_number = NULL,
             $page_size = NULL, $order_field = NULL, $order_direction = NULL) {
 
-            return $this->get_request_paged($this->_lists_base_route.'unconfirmed.json?date='.urlencode($added_since), 
+            return $this->get_request_paged($this->_lists_base_route.'unconfirmed.json?date='.urlencode($added_since),
                 $page_number, $page_size, $order_field, $order_direction);
         }
 
@@ -364,10 +364,10 @@ if (!class_exists('CS_REST_Lists')) {
          *     )
          * }
          */
-        function get_bounced_subscribers($bounced_since = '', $page_number = NULL, 
+        function get_bounced_subscribers($bounced_since = '', $page_number = NULL,
             $page_size = NULL, $order_field = NULL, $order_direction = NULL) {
-                
-            return $this->get_request_paged($this->_lists_base_route.'bounced.json?date='.urlencode($bounced_since), 
+
+            return $this->get_request_paged($this->_lists_base_route.'bounced.json?date='.urlencode($bounced_since),
                 $page_number, $page_size, $order_field, $order_direction);
         }
 
@@ -404,10 +404,10 @@ if (!class_exists('CS_REST_Lists')) {
          *     )
          * }
          */
-        function get_unsubscribed_subscribers($unsubscribed_since = '', $page_number = NULL, 
+        function get_unsubscribed_subscribers($unsubscribed_since = '', $page_number = NULL,
             $page_size = NULL, $order_field = NULL, $order_direction = NULL) {
-                
-            return $this->get_request_paged($this->_lists_base_route.'unsubscribed.json?date='.urlencode($unsubscribed_since), 
+
+            return $this->get_request_paged($this->_lists_base_route.'unsubscribed.json?date='.urlencode($unsubscribed_since),
                 $page_number, $page_size, $order_field, $order_direction);
         }
 
@@ -444,10 +444,10 @@ if (!class_exists('CS_REST_Lists')) {
          *     )
          * }
          */
-        function get_deleted_subscribers($deleted_since = '', $page_number = NULL, 
+        function get_deleted_subscribers($deleted_since = '', $page_number = NULL,
             $page_size = NULL, $order_field = NULL, $order_direction = NULL) {
-                
-            return $this->get_request_paged($this->_lists_base_route.'deleted.json?date='.urlencode($deleted_since), 
+
+            return $this->get_request_paged($this->_lists_base_route.'deleted.json?date='.urlencode($deleted_since),
                 $page_number, $page_size, $order_field, $order_direction);
         }
 
@@ -505,7 +505,7 @@ if (!class_exists('CS_REST_Lists')) {
         function get_stats() {
             return $this->get_request($this->_lists_base_route.'stats.json');
         }
-        
+
         /**
          * Gets the webhooks which are currently subcribed to event on this list
          * @access public
@@ -523,15 +523,15 @@ if (!class_exists('CS_REST_Lists')) {
         function get_webhooks() {
             return $this->get_request($this->_lists_base_route.'webhooks.json');
         }
-       
+
         /**
          * Creates a new webhook based on the provided details
          * @param array $webhook The details of the new webhook
          *     This array should be of the form
          *     array(
-         *         'Events' => array<string> The events to subscribe to. Valid events are 
-         *             CS_REST_LIST_WEBHOOK_SUBSCRIBE, 
-         *             CS_REST_LIST_WEBHOOK_DEACTIVATE, 
+         *         'Events' => array<string> The events to subscribe to. Valid events are
+         *             CS_REST_LIST_WEBHOOK_SUBSCRIBE,
+         *             CS_REST_LIST_WEBHOOK_DEACTIVATE,
          *             CS_REST_LIST_WEBHOOK_UPDATE
          *         'Url' => string The url of the page to POST the webhook events to
          *         'PayloadFormat' => The format to use when POSTing webhook event data, either
@@ -543,18 +543,18 @@ if (!class_exists('CS_REST_Lists')) {
          * @return CS_REST_Wrapper_Result A successful response will be the ID of the newly created webhook
          */
         function create_webhook($webhook) {
-            return $this->post_request($this->_lists_base_route.'webhooks.json', $webhook);    
+            return $this->post_request($this->_lists_base_route.'webhooks.json', $webhook);
         }
-        
+
         /**
          * Sends test events for the given webhook id
          * @param string $webhook_id The id of the webhook to test
          * @access public
-         * @return CS_REST_Wrapper_Result A successful response will be empty. 
+         * @return CS_REST_Wrapper_Result A successful response will be empty.
          */
         function test_webhook($webhook_id) {
             return $this->get_request($this->_lists_base_route.'webhooks/'.$webhook_id.'/test.json');
-        }    
+        }
 
         /**
          * Deletes an existing webhook from the system
@@ -565,7 +565,7 @@ if (!class_exists('CS_REST_Lists')) {
         function delete_webhook($webhook_id) {
             return $this->delete_request($this->_lists_base_route.'webhooks/'.$webhook_id.'.json');
         }
-        
+
         /**
          * Activates an existing deactivated webhook
          * @param string $webhook_id The id of the webhook to activate
@@ -575,7 +575,7 @@ if (!class_exists('CS_REST_Lists')) {
         function activate_webhook($webhook_id) {
             return $this->put_request($this->_lists_base_route.'webhooks/'.$webhook_id.'/activate.json', '');
         }
-        
+
         /**
          * Deactivates an existing activated webhook
          * @param string $webhook_id The id of the webhook to deactivate

--- a/csrest_people.php
+++ b/csrest_people.php
@@ -8,7 +8,7 @@ require_once dirname(__FILE__).'/class/base_classes.php';
  * @author tobyb
  *
  */
-if (!class_exists('CS_REST_People')) {
+if (!@class_exists('CS_REST_People')) {
     class CS_REST_People extends CS_REST_Wrapper_Base {
 
         /**
@@ -82,7 +82,7 @@ if (!class_exists('CS_REST_People')) {
         /**
          * Updates details for an existing person associated with the specified client.
     	 * @param string $email The email address of the person to be updated
-         * @param array $person The updated person details to use for the update. 
+         * @param array $person The updated person details to use for the update.
          *     This array should be of the form
          *     array (
          *         'EmailAddress' => The new  email address
@@ -105,7 +105,7 @@ if (!class_exists('CS_REST_People')) {
          *     'EmailAddress' => The email address of the person
          *     'Name' => The name of the person
          *     'Status' => The status of the person
-         *     'AccessLevel' => The access level of the person     
+         *     'AccessLevel' => The access level of the person
          *     )
          * }
          */

--- a/csrest_segments.php
+++ b/csrest_segments.php
@@ -8,7 +8,7 @@ require_once dirname(__FILE__).'/class/base_classes.php';
  * @author tobyb
  *
  */
-if (!class_exists('CS_REST_Segments')) {
+if (!@class_exists('CS_REST_Segments')) {
     class CS_REST_Segments extends CS_REST_Wrapper_Base {
 
         /**
@@ -60,12 +60,12 @@ if (!class_exists('CS_REST_Segments')) {
         function set_segment_id($segment_id) {
             $this->_segments_base_route = $this->_base_route.'segments/'.$segment_id;
         }
-        
+
         /**
          * Creates a new segment on the given list with the provided details
          * @param int $list_id The list on which to create the segment
          * @param $segment_details The details of the new segment
-         *     This should be an array of the form 
+         *     This should be an array of the form
          *         array(
          *             'Title' => The title of the new segment
          *             'RuleGroups' => array(
@@ -83,12 +83,12 @@ if (!class_exists('CS_REST_Segments')) {
          */
         function create($list_id, $segment_details) {
             return $this->post_request($this->_base_route.'segments/'.$list_id.'.json', $segment_details);
-        }    
-        
+        }
+
         /**
          * Updates the current segment with the provided details. Calls to this route will clear any existing rules
          * @param $segment_details The new details for the segment
-         *     This should be an array of the form 
+         *     This should be an array of the form
          *         array(
          *             'Title' => The title of the new segment
          *             'RuleGroups' => array(
@@ -106,8 +106,8 @@ if (!class_exists('CS_REST_Segments')) {
          */
         function update($segment_details) {
             return $this->put_request($this->_segments_base_route.'.json', $segment_details);
-        }    
-        
+        }
+
         /**
          * Adds the given rule to the current segment
          * @param $rule The rule to add to the segment
@@ -125,7 +125,7 @@ if (!class_exists('CS_REST_Segments')) {
         function add_rulegroup($rulegroup) {
             return $this->post_request($this->_segments_base_route.'/rules.json', $rulegroup);
         }
-        
+
         /**
          * Gets the details of the current segment
          * @access public
@@ -164,10 +164,10 @@ if (!class_exists('CS_REST_Segments')) {
         function clear_rules() {
             return $this->delete_request($this->_segments_base_route.'/rules.json');
         }
-        
+
         /**
          * Gets a paged collection of subscribers which fall into the given segment
-         * @param string $subscribed_since The date to start getting subscribers from 
+         * @param string $subscribed_since The date to start getting subscribers from
          * @param int $page_number The page number to get
          * @param int $page_size The number of records per page
          * @param string $order_field The field to order the record set by ('EMAIL', 'NAME', 'DATE')
@@ -198,10 +198,10 @@ if (!class_exists('CS_REST_Segments')) {
          *     )
          * }
          */
-        function get_subscribers($subscribed_since = '', $page_number = NULL, 
+        function get_subscribers($subscribed_since = '', $page_number = NULL,
             $page_size = NULL, $order_field = NULL, $order_direction = NULL) {
-                
-            return $this->get_request_paged($this->_segments_base_route.'/active.json?date='.urlencode($subscribed_since), 
+
+            return $this->get_request_paged($this->_segments_base_route.'/active.json?date='.urlencode($subscribed_since),
                 $page_number, $page_size, $order_field, $order_direction);
         }
     }

--- a/csrest_subscribers.php
+++ b/csrest_subscribers.php
@@ -8,7 +8,7 @@ require_once dirname(__FILE__).'/class/base_classes.php';
  * @author tobyb
  *
  */
-if (!class_exists('CS_REST_Subscribers')) {
+if (!@class_exists('CS_REST_Subscribers')) {
     class CS_REST_Subscribers extends CS_REST_Wrapper_Base {
 
         /**
@@ -156,7 +156,7 @@ if (!class_exists('CS_REST_Subscribers')) {
     		    'Subscribers' => $subscribers,
                 'RestartSubscriptionBasedAutoresponders' => $restartSubscriptionBasedAutoResponders
             );
-            
+
             return $this->post_request($this->_subscribers_base_route.'/import.json', $subscribers);
         }
 
@@ -214,9 +214,9 @@ if (!class_exists('CS_REST_Subscribers')) {
         function unsubscribe($email) {
             // We need to build the subscriber data structure.
             $email = array(
-    		    'EmailAddress' => $email 
+    		    'EmailAddress' => $email
             );
-            
+
             return $this->post_request($this->_subscribers_base_route.'/unsubscribe.json', $email);
         }
 

--- a/csrest_templates.php
+++ b/csrest_templates.php
@@ -7,7 +7,7 @@ require_once dirname(__FILE__).'/class/base_classes.php';
  * @author tobyb
  *
  */
-if (!class_exists('CS_REST_Templates')) {
+if (!@class_exists('CS_REST_Templates')) {
     class CS_REST_Templates extends CS_REST_Wrapper_Base {
 
         /**
@@ -57,7 +57,7 @@ if (!class_exists('CS_REST_Templates')) {
          * @access public
          */
         function set_template_id($template_id) {
-            $this->_templates_base_route = $this->_base_route.'templates/'.$template_id.'.json';            
+            $this->_templates_base_route = $this->_base_route.'templates/'.$template_id.'.json';
         }
 
         /**

--- a/csrest_transactional_classicemail.php
+++ b/csrest_transactional_classicemail.php
@@ -6,7 +6,7 @@ require_once dirname(__FILE__).'/class/base_classes.php';
  * @author philoye
  *
  */
-if (!class_exists('CS_REST_Transactional_ClassicEmail')) {
+if (!@class_exists('CS_REST_Transactional_ClassicEmail')) {
     class CS_REST_Transactional_ClassicEmail extends CS_REST_Wrapper_Base {
 
         /**
@@ -130,4 +130,3 @@ if (!class_exists('CS_REST_Transactional_ClassicEmail')) {
 
     }
 }
-

--- a/csrest_transactional_smartemail.php
+++ b/csrest_transactional_smartemail.php
@@ -7,7 +7,7 @@ require_once dirname(__FILE__).'/class/base_classes.php';
  *
  */
 
-if (!class_exists('CS_REST_Transactional_SmartEmail')) {
+if (!@class_exists('CS_REST_Transactional_SmartEmail')) {
     class CS_REST_Transactional_SmartEmail extends CS_REST_Wrapper_Base {
 
         /**

--- a/csrest_transactional_timeline.php
+++ b/csrest_transactional_timeline.php
@@ -6,7 +6,7 @@ require_once dirname(__FILE__).'/class/base_classes.php';
  * @author philoye
  *
  */
-if (!class_exists('CS_REST_Transactional_Timeline')) {
+if (!@class_exists('CS_REST_Transactional_Timeline')) {
     class CS_REST_Transactional_Timeline extends CS_REST_Wrapper_Base {
 
         /**
@@ -158,4 +158,3 @@ if (!class_exists('CS_REST_Transactional_Timeline')) {
 
     }
 }
-


### PR DESCRIPTION
Suppress error on class_exists() calls, when class_exists() is wrapped around a class definition.  This prevents errors on applications that assume class names correspond to file names, and who attempt to require said files on autoload (*cough* yii1 *cough*).