### PR TITLE
Fixed get_suppressionlist method

### DIFF
--- a/csrest_clients.php
+++ b/csrest_clients.php
@@ -210,7 +210,7 @@ if (!class_exists('CS_REST_Clients')) {
             $order_direction = NULL) {
                 
             return $this->get_request_paged($this->_clients_base_route.'suppressionlist.json', 
-                $page_number, $page_size, $order_field, $order_direction, '?');
+                $page_number, $page_size, $order_field, $order_direction, NULL, '?');
         }
 
         /**


### PR DESCRIPTION
Adding missing parameter for get_request_paged which is causing get_suppressionlist to break.