### PR TITLE
Update user agent to standard + get TravisCI build green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 5.3
+    dist: precise
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,13 @@ matrix:
     - php: 5.3
       dist: precise
     - php: 5.4
-      dist: trusty
     - php: 5.5
-      dist: trusty
     - php: 5.6
-      dist: trusty
     - php: 7.0
-      dist: trusty
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
     - php: hhvm-3.30
-      dist: trusty
-
+    
 before_script: composer install --dev
 script: cd tests && php all_tests.php && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       dist: trusty
     - php: 7.0
       dist: trusty
-    - php: hhvm
+    - php: hhvm-3.3
       dist: trusty
 
 before_script: composer install --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,15 @@ matrix:
     - php: 5.3
       dist: precise
     - php: 5.4
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.6
     - php: 7.0
     - php: 7.1
     - php: 7.2
     - php: 7.3
     - php: hhvm-3.30
-    
+
 before_script: composer install --dev
 script: cd tests && php all_tests.php && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: php
 
-php:
-  - 5.5
-    dist: precise
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm-3.30
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
+    - php: 5.6
+      dist: trusty
+    - php: 7.0
+      dist: trusty
+    - php: hhvm-3.30
+      dist: trusty
 
 before_script: composer install --dev
 script: cd tests && php all_tests.php && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
       dist: trusty
     - php: hhvm
       dist: trusty
-      env:
-        - HHVMPHP7=1
 
 before_script: composer install --dev
 script: cd tests && php all_tests.php && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       dist: trusty
     - php: hhvm
       dist: trusty
+      env:
+        - HHVMPHP7=1
 
 before_script: composer install --dev
 script: cd tests && php all_tests.php && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
 language: php
 
 php:
-  - 5.3
+  - 5.5
+    dist: precise
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - hhvm-3.30
-
-matrix:
-  include:
-    -php: 5.3
-     dist: precise
 
 before_script: composer install --dev
 script: cd tests && php all_tests.php && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 matrix:
   include:
     - php: 5.3
-      dist: xenial
+      dist: precise
     - php: 5.4
       dist: trusty
     - php: 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       dist: trusty
     - php: 7.0
       dist: trusty
-    - php: hhvm
+    - php: hhvm-3.30
       dist: trusty
 
 before_script: composer install --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       dist: trusty
     - php: 7.0
       dist: trusty
-    - hhvm
+    - php: hhvm
       dist: trusty
 
 before_script: composer install --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,13 @@
 language: php
 
-matrix:
-  include:
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-      dist: trusty
-    - php: 5.5
-      dist: trusty
-    - php: 5.6
-      dist: trusty
-    - php: 7.0
-      dist: trusty
-    - php: hhvm-3.30
-      dist: trusty
+php:
+  - 5.5
+    dist: precise
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm-3.30
 
 before_script: composer install --dev
 script: cd tests && php all_tests.php && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: php
 
-php:
-  - 5.3
-    dist: precise
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
+    - php: 5.6
+      dist: trusty
+    - php: 7.0
+      dist: trusty
+    - php: hhvm
+      dist: trusty
 
 before_script: composer install --dev
 script: cd tests && php all_tests.php && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: php
 
 php:
-  - 5.5
-    dist: precise
+  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - hhvm-3.30
+
+matrix:
+  include:
+    -php: 5.3
+     dist: precise
 
 before_script: composer install --dev
 script: cd tests && php all_tests.php && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 matrix:
   include:
     - php: 5.3
-      dist: precise
+      dist: xenial
     - php: 5.4
       dist: trusty
     - php: 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,7 @@ matrix:
     - php: hhvm
       dist: trusty
 
-before_script: composer install --dev
+before_script: 
+  - composer install --dev
+  - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
 script: cd tests && php all_tests.php && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,5 @@ matrix:
     - php: hhvm
       dist: trusty
 
-before_script: 
-  - composer install --dev
-  - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
+before_script: composer install --dev
 script: cd tests && php all_tests.php && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       dist: trusty
     - php: 7.0
       dist: trusty
-    - php: hhvm-3.3
+    - hhvm
       dist: trusty
 
 before_script: composer install --dev

--- a/class/base_classes.php
+++ b/class/base_classes.php
@@ -4,7 +4,7 @@ require_once dirname(__FILE__).'/serialisation.php';
 require_once dirname(__FILE__).'/transport.php';
 require_once dirname(__FILE__).'/log.php';
 
-defined('CS_REST_WRAPPER_VERSION') or define('CS_REST_WRAPPER_VERSION', '6.0.0');
+defined('CS_REST_WRAPPER_VERSION') or define('CS_REST_WRAPPER_VERSION', '6.0.1');
 defined('CS_HOST') or define('CS_HOST', 'api.createsend.com');
 defined('CS_OAUTH_BASE_URI') or define('CS_OAUTH_BASE_URI', 'https://'.CS_HOST.'/oauth');
 defined('CS_OAUTH_TOKEN_URI') or define('CS_OAUTH_TOKEN_URI', CS_OAUTH_BASE_URI.'/token');
@@ -164,7 +164,7 @@ if (!class_exists('CS_REST_Wrapper_Base')) {
 
             $this->_default_call_options = array (
                 'authdetails' => $auth_details,
-                'userAgent' => 'CS_REST_Wrapper v'.CS_REST_WRAPPER_VERSION.
+                'userAgent' => 'createsend-php v'.CS_REST_WRAPPER_VERSION.
                     ' PHPv'.phpversion().' over '.$transport_type.' with '.$this->_serialiser->get_type(),
                 'contentType' => 'application/json; charset=utf-8',
                 'deserialise' => true,

--- a/class/base_classes.php
+++ b/class/base_classes.php
@@ -257,7 +257,7 @@ if (!class_exists('CS_REST_Wrapper_Base')) {
         function get_request_paged($route, $page_number, $page_size, $order_field, $order_direction, $include_tracking_pref = NULL,
             $join_char = 'deprecated') {
             // Stores our query values
-            $query = [];
+            $query = array();
             // Extract any initial queries in the route into our local query
             if(strpos($route, '?') !== false) {
                 $parts = parse_url($route);

--- a/tests/csrest_test.php
+++ b/tests/csrest_test.php
@@ -45,7 +45,7 @@ class CS_REST_TestBase extends UnitTestCase {
     function get_call_options($route, $method = 'GET') {
         return array (
             'authdetails' => $this->auth,
-            'userAgent' => 'CS_REST_Wrapper v'.CS_REST_WRAPPER_VERSION.
+            'userAgent' => 'createsend-php v'.CS_REST_WRAPPER_VERSION.
             ' PHPv'.phpversion().' over '.$this->transport_type.' with '.$this->serialisation_type,
             'contentType' => 'application/json; charset=utf-8',
             'deserialise' => true,


### PR DESCRIPTION
Update UserAgent string to standard CM wrapper prefix format: ```createsend-```

Updates to ```.travisci.yml``` to get build pipeline green. Force dist type on specific PHP versions + limit hhvm build to last known build to support PHP (3.30)