### PR TITLE
Php 7.4 Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
+    - php: 7.4
     - php: hhvm-3.30
 
 before_script: composer install --dev

--- a/class/services_json.php
+++ b/class/services_json.php
@@ -153,7 +153,7 @@ if (!class_exists('Services_JSON')) {
                 return mb_convert_encoding($utf16, 'UTF-8', 'UTF-16');
             }
 
-            $bytes = (ord($utf16{0}) << 8) | ord($utf16{1});
+            $bytes = (ord($utf16[0]) << 8) | ord($utf16[1]);
 
             switch(true) {
                 case ((0x7F & $bytes) == $bytes):
@@ -206,17 +206,17 @@ if (!class_exists('Services_JSON')) {
                 case 2:
                     // return a UTF-16 character from a 2-byte UTF-8 char
                     // see: http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                    return chr(0x07 & (ord($utf8{0}) >> 2))
-                         . chr((0xC0 & (ord($utf8{0}) << 6))
-                             | (0x3F & ord($utf8{1})));
+                    return chr(0x07 & (ord($utf8[0]) >> 2))
+                         . chr((0xC0 & (ord($utf8[0]) << 6))
+                             | (0x3F & ord($utf8[1])));
 
                 case 3:
                     // return a UTF-16 character from a 3-byte UTF-8 char
                     // see: http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                    return chr((0xF0 & (ord($utf8{0}) << 4))
-                             | (0x0F & (ord($utf8{1}) >> 2)))
-                         . chr((0xC0 & (ord($utf8{1}) << 6))
-                             | (0x7F & ord($utf8{2})));
+                    return chr((0xF0 & (ord($utf8[0]) << 4))
+                             | (0x0F & (ord($utf8[1]) >> 2)))
+                         . chr((0xC0 & (ord($utf8[1]) << 6))
+                             | (0x7F & ord($utf8[2])));
             }
 
             // ignoring UTF-32 for now, sorry
@@ -261,7 +261,7 @@ if (!class_exists('Services_JSON')) {
                     */
                     for ($c = 0; $c < $strlen_var; ++$c) {
 
-                        $ord_var_c = ord($var{$c});
+                        $ord_var_c = ord($var[$c]);
 
                         switch (true) {
                             case $ord_var_c == 0x08:
@@ -284,18 +284,18 @@ if (!class_exists('Services_JSON')) {
                             case $ord_var_c == 0x2F:
                             case $ord_var_c == 0x5C:
                                 // double quote, slash, slosh
-                                $ascii .= '\\'.$var{$c};
+                                $ascii .= '\\'.$var[$c];
                                 break;
 
                             case (($ord_var_c >= 0x20) && ($ord_var_c <= 0x7F)):
                                 // characters U-00000000 - U-0000007F (same as ASCII)
-                                $ascii .= $var{$c};
+                                $ascii .= $var[$c];
                                 break;
 
                             case (($ord_var_c & 0xE0) == 0xC0):
                                 // characters U-00000080 - U-000007FF, mask 110XXXXX
                                 // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                                $char = pack('C*', $ord_var_c, ord($var{$c + 1}));
+                                $char = pack('C*', $ord_var_c, ord($var[$c + 1]));
                                 $c += 1;
                                 $utf16 = $this->utf82utf16($char);
                                 $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -305,8 +305,8 @@ if (!class_exists('Services_JSON')) {
                                 // characters U-00000800 - U-0000FFFF, mask 1110XXXX
                                 // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                                 $char = pack('C*', $ord_var_c,
-                                             ord($var{$c + 1}),
-                                             ord($var{$c + 2}));
+                                             ord($var[$c + 1]),
+                                             ord($var[$c + 2]));
                                 $c += 2;
                                 $utf16 = $this->utf82utf16($char);
                                 $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -316,9 +316,9 @@ if (!class_exists('Services_JSON')) {
                                 // characters U-00010000 - U-001FFFFF, mask 11110XXX
                                 // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                                 $char = pack('C*', $ord_var_c,
-                                             ord($var{$c + 1}),
-                                             ord($var{$c + 2}),
-                                             ord($var{$c + 3}));
+                                             ord($var[$c + 1]),
+                                             ord($var[$c + 2]),
+                                             ord($var[$c + 3]));
                                 $c += 3;
                                 $utf16 = $this->utf82utf16($char);
                                 $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -328,10 +328,10 @@ if (!class_exists('Services_JSON')) {
                                 // characters U-00200000 - U-03FFFFFF, mask 111110XX
                                 // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                                 $char = pack('C*', $ord_var_c,
-                                             ord($var{$c + 1}),
-                                             ord($var{$c + 2}),
-                                             ord($var{$c + 3}),
-                                             ord($var{$c + 4}));
+                                             ord($var[$c + 1]),
+                                             ord($var[$c + 2]),
+                                             ord($var[$c + 3]),
+                                             ord($var[$c + 4]));
                                 $c += 4;
                                 $utf16 = $this->utf82utf16($char);
                                 $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -341,11 +341,11 @@ if (!class_exists('Services_JSON')) {
                                 // characters U-04000000 - U-7FFFFFFF, mask 1111110X
                                 // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                                 $char = pack('C*', $ord_var_c,
-                                             ord($var{$c + 1}),
-                                             ord($var{$c + 2}),
-                                             ord($var{$c + 3}),
-                                             ord($var{$c + 4}),
-                                             ord($var{$c + 5}));
+                                             ord($var[$c + 1]),
+                                             ord($var[$c + 2]),
+                                             ord($var[$c + 3]),
+                                             ord($var[$c + 4]),
+                                             ord($var[$c + 5]));
                                 $c += 5;
                                 $utf16 = $this->utf82utf16($char);
                                 $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -520,7 +520,7 @@ if (!class_exists('Services_JSON')) {
                         for ($c = 0; $c < $strlen_chrs; ++$c) {
 
                             $substr_chrs_c_2 = substr($chrs, $c, 2);
-                            $ord_chrs_c = ord($chrs{$c});
+                            $ord_chrs_c = ord($chrs[$c]);
 
                             switch (true) {
                                 case $substr_chrs_c_2 == '\b':
@@ -693,7 +693,7 @@ if (!class_exists('Services_JSON')) {
 
                             } elseif ((($chrs{$c} == '"') || ($chrs{$c} == "'")) && ($top['what'] != SERVICES_JSON_IN_STR)) {
                                 // found a quote, and we are not inside a string
-                                array_push($stk, array('what' => SERVICES_JSON_IN_STR, 'where' => $c, 'delim' => $chrs{$c}));
+                                array_push($stk, array('what' => SERVICES_JSON_IN_STR, 'where' => $c, 'delim' => $chrs[$c]));
                                 //print("Found start of string at {$c}\n");
 
                             } elseif (($chrs{$c} == $top['delim']) &&

--- a/class/services_json.php
+++ b/class/services_json.php
@@ -550,7 +550,7 @@ if (!class_exists('Services_JSON')) {
                                 case $substr_chrs_c_2 == '\\/':
                                     if (($delim == '"' && $substr_chrs_c_2 != '\\\'') ||
                                        ($delim == "'" && $substr_chrs_c_2 != '\\"')) {
-                                        $utf8 .= $chrs{++$c};
+                                        $utf8 .= $chrs[++$c];
                                     }
                                     break;
 
@@ -563,7 +563,7 @@ if (!class_exists('Services_JSON')) {
                                     break;
 
                                 case ($ord_chrs_c >= 0x20) && ($ord_chrs_c <= 0x7F):
-                                    $utf8 .= $chrs{$c};
+                                    $utf8 .= $chrs[$c];
                                     break;
 
                                 case ($ord_chrs_c & 0xE0) == 0xC0:
@@ -610,7 +610,7 @@ if (!class_exists('Services_JSON')) {
                     } elseif (preg_match('/^\[.*\]$/s', $str) || preg_match('/^\{.*\}$/s', $str)) {
                         // array, or object notation
 
-                        if ($str{0} == '[') {
+                        if ($str[0] == '[') {
                             $stk = array(SERVICES_JSON_IN_ARR);
                             $arr = array();
                         } else {
@@ -649,7 +649,7 @@ if (!class_exists('Services_JSON')) {
                             $top = end($stk);
                             $substr_chrs_c_2 = substr($chrs, $c, 2);
 
-                            if (($c == $strlen_chrs) || (($chrs{$c} == ',') && ($top['what'] == SERVICES_JSON_SLICE))) {
+                            if (($c == $strlen_chrs) || (($chrs[$c] == ',') && ($top['what'] == SERVICES_JSON_SLICE))) {
                                 // found a comma that is not inside a string, array, etc.,
                                 // OR we've reached the end of the character list
                                 $slice = substr($chrs, $top['where'], ($c - $top['where']));
@@ -691,12 +691,12 @@ if (!class_exists('Services_JSON')) {
 
                                 }
 
-                            } elseif ((($chrs{$c} == '"') || ($chrs{$c} == "'")) && ($top['what'] != SERVICES_JSON_IN_STR)) {
+                            } elseif ((($chrs[$c] == '"') || ($chrs[$c] == "'")) && ($top['what'] != SERVICES_JSON_IN_STR)) {
                                 // found a quote, and we are not inside a string
                                 array_push($stk, array('what' => SERVICES_JSON_IN_STR, 'where' => $c, 'delim' => $chrs[$c]));
                                 //print("Found start of string at {$c}\n");
 
-                            } elseif (($chrs{$c} == $top['delim']) &&
+                            } elseif (($chrs[$c] == $top['delim']) &&
                                      ($top['what'] == SERVICES_JSON_IN_STR) &&
                                      ((strlen(substr($chrs, 0, $c)) - strlen(rtrim(substr($chrs, 0, $c), '\\'))) % 2 != 1)) {
                                 // found a quote, we're in a string, and it's not escaped
@@ -705,24 +705,24 @@ if (!class_exists('Services_JSON')) {
                                 array_pop($stk);
                                 //print("Found end of string at {$c}: ".substr($chrs, $top['where'], (1 + 1 + $c - $top['where']))."\n");
 
-                            } elseif (($chrs{$c} == '[') &&
+                            } elseif (($chrs[$c] == '[') &&
                                      in_array($top['what'], array(SERVICES_JSON_SLICE, SERVICES_JSON_IN_ARR, SERVICES_JSON_IN_OBJ))) {
                                 // found a left-bracket, and we are in an array, object, or slice
                                 array_push($stk, array('what' => SERVICES_JSON_IN_ARR, 'where' => $c, 'delim' => false));
                                 //print("Found start of array at {$c}\n");
 
-                            } elseif (($chrs{$c} == ']') && ($top['what'] == SERVICES_JSON_IN_ARR)) {
+                            } elseif (($chrs[$c] == ']') && ($top['what'] == SERVICES_JSON_IN_ARR)) {
                                 // found a right-bracket, and we're in an array
                                 array_pop($stk);
                                 //print("Found end of array at {$c}: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");
 
-                            } elseif (($chrs{$c} == '{') &&
+                            } elseif (($chrs[$c] == '{') &&
                                      in_array($top['what'], array(SERVICES_JSON_SLICE, SERVICES_JSON_IN_ARR, SERVICES_JSON_IN_OBJ))) {
                                 // found a left-brace, and we are in an array, object, or slice
                                 array_push($stk, array('what' => SERVICES_JSON_IN_OBJ, 'where' => $c, 'delim' => false));
                                 //print("Found start of object at {$c}\n");
 
-                            } elseif (($chrs{$c} == '}') && ($top['what'] == SERVICES_JSON_IN_OBJ)) {
+                            } elseif (($chrs[$c] == '}') && ($top['what'] == SERVICES_JSON_IN_OBJ)) {
                                 // found a right-brace, and we're in an object
                                 array_pop($stk);
                                 //print("Found end of object at {$c}: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate_curly_braces_array_access

PHP7.4 Deprecate curly brace syntax for accessing array elements and string offsets