### PR TITLE
Added ConsentToTrack

### DIFF
--- a/samples/subscriber/import.php
+++ b/samples/subscriber/import.php
@@ -28,7 +28,8 @@ $result = $wrap->import(array(
 	            'Key' => 'Multi Option Field 1',
 	            'Value' => 'Option 2'
 	        )
-            )
+            ),
+	    'ConsentToTrack' => 'yes',
 	),
 	array(
 	    'EmailAddress' => '2nd Subscriber email',
@@ -50,7 +51,8 @@ $result = $wrap->import(array(
 	            'Key' => 'Multi Option Field 1',
 	            'Value' => 'Option 2'
 	        )
-	    )
+	    ),
+	    'ConsentToTrack' => 'yes',
 	)
 ), false);
 


### PR DESCRIPTION
The ConsentToTrack field is mandatory and should be a valid value ('yes' or 'no').
If you don't add it, the API will return an error that it is mandatory.