### PR TITLE
increase default timeout to 120secs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # createsend-php history
 
+## v6.1.2 - 2nd Oct, 2021
+
+* Changed local API timeout from 20 secs to 120 secs
+
 ## v6.1.1 - 6th May, 2020
 
 * Add PHP 7.4 Support

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## v6.1.2 - 2nd Oct, 2021
 
-* Changed local API timeout from 20 secs to 120 secs
+* Changed local API timeout from 20 secs to 120 secs to cater for changes on get segment subscribers API endpoint.
 
 ## v6.1.1 - 6th May, 2020
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ $result = $wrap->get_clients();
 var_dump($result->response);
 ```
 ## API Call Timeout
-You can set your local API call timeout time in createsend-php\class\transport.php line 11, in the CS_REST_CALL_TIMEOUT variable. Currently the default is 20 secs.
+You can set your local API call timeout time in createsend-php\class\transport.php line 11, in the CS_REST_CALL_TIMEOUT variable. Currently the default is 120 secs.
 
 ## Examples
 

--- a/class/base_classes.php
+++ b/class/base_classes.php
@@ -4,7 +4,7 @@ require_once dirname(__FILE__).'/serialisation.php';
 require_once dirname(__FILE__).'/transport.php';
 require_once dirname(__FILE__).'/log.php';
 
-defined('CS_REST_WRAPPER_VERSION') or define('CS_REST_WRAPPER_VERSION', '6.1.1');
+defined('CS_REST_WRAPPER_VERSION') or define('CS_REST_WRAPPER_VERSION', '6.1.2');
 defined('CS_HOST') or define('CS_HOST', 'api.createsend.com');
 defined('CS_OAUTH_BASE_URI') or define('CS_OAUTH_BASE_URI', 'https://'.CS_HOST.'/oauth');
 defined('CS_OAUTH_TOKEN_URI') or define('CS_OAUTH_TOKEN_URI', CS_OAUTH_BASE_URI.'/token');

--- a/class/transport.php
+++ b/class/transport.php
@@ -5,10 +5,10 @@ defined('CS_REST_POST') or define('CS_REST_POST', 'POST');
 defined('CS_REST_PUT') or define('CS_REST_PUT', 'PUT');
 defined('CS_REST_DELETE') or define('CS_REST_DELETE', 'DELETE');
 if (false === defined('CS_REST_SOCKET_TIMEOUT')) {
-    define('CS_REST_SOCKET_TIMEOUT', 20);
+    define('CS_REST_SOCKET_TIMEOUT', 120);
 }
 if (false === defined('CS_REST_CALL_TIMEOUT')) {
-    define('CS_REST_CALL_TIMEOUT', 20);
+    define('CS_REST_CALL_TIMEOUT', 120);
 }
 
 if(!function_exists("CS_REST_TRANSPORT_get_available")) {    


### PR DESCRIPTION
Increasing default timeout to accomodate increases in response time on Get Active Segment Subscribers endpoint.