### PR TITLE
EL-282 Add support for Createsend API v3.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@
 * Upgrades to Createsend API v3.3 which includes new breaking changes
 * Breaking: client sent campaigns endpoint is now paginated and filtered
 * Added new client tags endpoint
-* Added support for returning campaign name as part of sent, draft and scheduled campaign endpoints
+* Added support for returning campaign tags as part of sent, draft and scheduled campaign endpoints
 * Added support for returning campaign name as part of campaign summary endpoint
 * Added sample script for get client tags endpoint
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # createsend-php history
 
-## v7.0.0 - 15th Dec, 2021
+## v7.0.0 - 11th Feb, 2022
 
 * Upgrades to Createsend API v3.3 which includes new breaking changes
 * Breaking: client sent campaigns endpoint is now paginated and filtered

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,14 @@
 # createsend-php history
 
+## v7.0.0 - 22nd Nov, 2021
+
+* Upgrades to Createsend API v3.3 which includes new breaking changes
+* Breaking: client sent campaigns endpoint is now paginated and filtered
+* Added new client tags endpoint
+* Added support for returning campaign name as part of sent, draft and scheduled campaign endpoints
+* Added support for returning campaign name as part of campaign summary endpoint
+* Added sample script for get client tags endpoint
+
 ## v6.1.2 - 2nd Oct, 2021
 
 * Changed local API timeout from 20 secs to 120 secs to cater for changes on get segment subscribers API endpoint.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # createsend-php history
 
-## v7.0.0 - 22nd Nov, 2021
+## v7.0.0 - 15th Dec, 2021
 
 * Upgrades to Createsend API v3.3 which includes new breaking changes
 * Breaking: client sent campaigns endpoint is now paginated and filtered
@@ -8,6 +8,14 @@
 * Added support for returning campaign tags as part of sent, draft and scheduled campaign endpoints
 * Added support for returning campaign name as part of campaign summary endpoint
 * Added sample script for get client tags endpoint
+* Adding support for returning ListJoinedDate for each subscriber. 
+  * List.Active()
+  * List.Bounced()
+  * List.Unsubscribed()
+  * List.Unconfirmed()
+  * List.Deleted()
+  * Segment.Subscribers()
+  * Subscriber.Get()
 
 ## v6.1.2 - 2nd Oct, 2021
 

--- a/class/base_classes.php
+++ b/class/base_classes.php
@@ -4,7 +4,7 @@ require_once dirname(__FILE__).'/serialisation.php';
 require_once dirname(__FILE__).'/transport.php';
 require_once dirname(__FILE__).'/log.php';
 
-defined('CS_REST_WRAPPER_VERSION') or define('CS_REST_WRAPPER_VERSION', '6.1.2');
+defined('CS_REST_WRAPPER_VERSION') or define('CS_REST_WRAPPER_VERSION', '7.0.0');
 defined('CS_HOST') or define('CS_HOST', 'api.createsend.com');
 defined('CS_OAUTH_BASE_URI') or define('CS_OAUTH_BASE_URI', 'https://'.CS_HOST.'/oauth');
 defined('CS_OAUTH_TOKEN_URI') or define('CS_OAUTH_TOKEN_URI', CS_OAUTH_BASE_URI.'/token');
@@ -146,7 +146,7 @@ if (!class_exists('CS_REST_Wrapper_Base')) {
             $this->_log = is_null($log) ? new CS_REST_Log($debug_level) : $log;
 
             $this->_protocol = $protocol;
-            $this->_base_route = $protocol.'://'.$host.'/api/v3.2/';
+            $this->_base_route = $protocol.'://'.$host.'/api/v3.3/';
 
             $this->_log->log_message('Creating wrapper for '.$this->_base_route, get_class($this), CS_REST_LOG_VERBOSE);
 

--- a/csrest_campaigns.php
+++ b/csrest_campaigns.php
@@ -258,6 +258,7 @@ if (!class_exists('CS_REST_Campaigns')) {
          * @access public
          * @return CS_REST_Wrapper_Result A successful response will be an object of the form
          * {
+         *     'Name' => The name of the campaign
          *     'Recipients' => The total recipients of the campaign
          *     'TotalOpened' => The total number of opens recorded
          *     'Clicks' => The total number of recorded clicks

--- a/csrest_clients.php
+++ b/csrest_clients.php
@@ -67,8 +67,8 @@ if (!class_exists('CS_REST_Clients')) {
          * @param int $page_number The page number to get
          * @param int $page_size The number of records per page
          * @param string $order_direction The direction to order the record set ('ASC', 'DESC')
-         * @param string $sentFromDate Only include campaigns after this date, in the format YYYY-MM-DD
-         * @param string $sentToDate Only include campaigns before this date, in the format YYYY-MM-DD
+         * @param string $sent_from_date Only include campaigns after this date, in the format YYYY-MM-DD
+         * @param string $sent_to_date Only include campaigns before this date, in the format YYYY-MM-DD
          * @access public
          * @return CS_REST_Wrapper_Result A successful response will be an object of the form
          * {

--- a/csrest_clients.php
+++ b/csrest_clients.php
@@ -96,19 +96,19 @@ if (!class_exists('CS_REST_Clients')) {
          *     )
          * }
          */
-        function get_campaigns($tags = NULL, $page_number = NULL, $page_size = NULL, $order_direction = NULL, $sentFromDate = NULL, $sentToDate = NULL) {
+        function get_campaigns($tags = NULL, $page_number = NULL, $page_size = NULL, $order_direction = NULL, $sent_from_date = NULL, $sent_to_date = NULL) {
             if(!is_null($tags)) {
                 $query['tags'] = is_array($tags)
                     ? implode(',', $tags)
                     : $tags;
             }
 
-            if(!is_null($sentFromDate)) {
-                $query['sentFromDate'] = $sentFromDate;
+            if(!is_null($sent_from_date)) {
+                $query['sentFromDate'] = $sent_from_date;
             }
 
-            if(!is_null($sentToDate)) {
-                $query['sentToDate'] = $sentToDate;
+            if(!is_null($sent_to_date)) {
+                $query['sentToDate'] = $sent_to_date;
             }
 
             $query = !empty($query) ? '?'.http_build_query($query) : '';

--- a/csrest_clients.php
+++ b/csrest_clients.php
@@ -114,7 +114,7 @@ if (!class_exists('CS_REST_Clients')) {
             $query = !empty($query) ? '?'.http_build_query($query) : '';
 
             return $this->get_request_paged($this->_clients_base_route.'campaigns.json'.$query,
-                $page_number, $page_size, null, $order_direction);
+                $page_number, $page_size, NULL, $order_direction);
         }
 
         /**

--- a/csrest_clients.php
+++ b/csrest_clients.php
@@ -63,25 +63,58 @@ if (!class_exists('CS_REST_Clients')) {
 
         /**
          * Gets a list of sent campaigns for the current client
+         * @param string|array $tags The array or comma separated string of tags to filter by
+         * @param int $page_number The page number to get
+         * @param int $page_size The number of records per page
+         * @param string $order_direction The direction to order the record set ('ASC', 'DESC')
+         * @param string $sentFromDate Only include campaigns after this date, in the format YYYY-MM-DD
+         * @param string $sentToDate Only include campaigns before this date, in the format YYYY-MM-DD
          * @access public
          * @return CS_REST_Wrapper_Result A successful response will be an object of the form
-         * array(
-         *     {
-         *         'WebVersionURL' => The web version url of the campaign
-         *         'WebVersionTextURL' => The web version url of the text version of the campaign
-         *         'CampaignID' => The id of the campaign
-         *         'Subject' => The campaign subject
-         *         'Name' => The name of the campaign
-         *         'FromName' => The from name for the campaign
-         *         'FromEmail' => The from email address for the campaign
-         *         'ReplyTo' => The reply to email address for the campaign
-         *         'SentDate' => The sent data of the campaign
-         *         'TotalRecipients' => The number of recipients of the campaign
-         *     }
-         * )
+         * {
+         *     'ResultsOrderedBy' => The field the results are ordered by
+         *     'OrderDirection' => The order direction
+         *     'PageNumber' => The page number for the result set
+         *     'PageSize' => The page size used
+         *     'RecordsOnThisPage' => The number of records returned
+         *     'TotalNumberOfRecords' => The total number of records available
+         *     'NumberOfPages' => The total number of pages for this collection
+         *     'Results' => array(
+         *         {
+         *             'WebVersionURL' => The web version url of the campaign
+         *             'WebVersionTextURL' => The web version url of the text version of the campaign
+         *             'CampaignID' => The id of the campaign
+         *             'Subject' => The campaign subject
+         *             'Name' => The name of the campaign
+         *             'FromName' => The from name for the campaign
+         *             'FromEmail' => The from email address for the campaign
+         *             'ReplyTo' => The reply to email address for the campaign
+         *             'SentDate' => The sent data of the campaign
+         *             'TotalRecipients' => The number of recipients of the campaign
+         *             'Tags' => An array of the tags associated with the campaign
+         *         }
+         *     )
+         * }
          */
-        function get_campaigns() {
-            return $this->get_request($this->_clients_base_route.'campaigns.json');
+        function get_campaigns($tags = NULL, $page_number = NULL, $page_size = NULL, $order_direction = NULL, $sentFromDate = NULL, $sentToDate = NULL) {
+            if(!is_null($tags)) {
+                $query['tags'] = is_array($tags)
+                    ? implode(',', $tags)
+                    : $tags;
+            }
+
+            if(!is_null($sentFromDate)) {
+                $query['sentFromDate'] = $sentFromDate;
+            }
+
+            if(!is_null($sentToDate)) {
+                $query['sentToDate'] = $sentToDate;
+            }
+
+            $query = !empty($query) ? '?'.http_build_query($query) : '';
+
+            return $this->get_request_paged($this->_clients_base_route.'campaigns.json'.$query,
+                $page_number, $page_size, null, $order_direction);
         }
 
         /**
@@ -101,6 +134,7 @@ if (!class_exists('CS_REST_Clients')) {
          *         'PreviewTextURL' => The preview url of the text version of the campaign
          *         'DateScheduled' => The date the campaign is scheduled to be sent
          *         'ScheduledTimeZone' => The time zone in which the campaign is scheduled to be sent at 'DateScheduled'
+         *         'Tags' => An array of the tags associated with the campaign
          *     }
          * )
          */
@@ -123,6 +157,7 @@ if (!class_exists('CS_REST_Clients')) {
          *         'DateCreated' => The date the campaign was created
          *         'PreviewURL' => The preview url of the draft campaign
          *         'PreviewTextURL' => The preview url of the text version of the campaign
+         *         'Tags' => An array of the tags associated with the campaign
          *     }
          * )
          */
@@ -248,6 +283,21 @@ if (!class_exists('CS_REST_Clients')) {
          */
         function get_templates() {
             return $this->get_request($this->_clients_base_route.'templates.json');
+        }
+
+        /**
+         * Get all the tags the current client has access to
+         * @access public
+         * @return CS_REST_Wrapper_Result A successful response will be an object of the form
+         * array(
+         *     {
+         *         'Name' => The name of the tag
+         *         'NumberOfCampaigns' => The number of campaigns the tag is used on
+         *     }
+         * )
+         */
+        function get_tags() {
+            return $this->get_request($this->_clients_base_route.'tags.json');
         }
 
         /**

--- a/csrest_lists.php
+++ b/csrest_lists.php
@@ -273,7 +273,8 @@ if (!class_exists('CS_REST_Lists')) {
          *         {
          *             'EmailAddress' => The email address of the subscriber
          *             'Name' => The name of the subscriber
-         *             'Date' => The date that the subscriber was added to the list
+         *             'Date' => The date when the status of subscriber last changed (ie: becomes active)
+         *             'ListJoinedDate' => The date the subscriber was first added to the list
          *             'State' => The current state of the subscriber, will be 'Active'
          *             'CustomFields' => array (
          *                 {
@@ -314,7 +315,8 @@ if (!class_exists('CS_REST_Lists')) {
          *         {
          *             'EmailAddress' => The email address of the subscriber
          *             'Name' => The name of the subscriber
-         *             'Date' => The date that the subscriber was added to the list
+         *             'Date' => The date when the status of subscriber last changed (ie: becomes unconfirmed)  
+         *             'ListJoinedDate' => The date the subscriber was first added to the list
          *             'State' => The current state of the subscriber, will be 'Unconfirmed'
          *             'CustomFields' => array (
          *                 {
@@ -355,7 +357,8 @@ if (!class_exists('CS_REST_Lists')) {
          *         {
          *             'EmailAddress' => The email address of the subscriber
          *             'Name' => The name of the subscriber
-         *             'Date' => The date that the subscriber bounced out of the list
+         *             'Date' => The date when the status of subscriber last changed (ie: becomes bounced)
+         *             'ListJoinedDate' => The date the subscriber was first added to the list
          *             'State' => The current state of the subscriber, will be 'Bounced'
          *             'CustomFields' => array (
          *                 {
@@ -396,7 +399,8 @@ if (!class_exists('CS_REST_Lists')) {
          *         {
          *             'EmailAddress' => The email address of the subscriber
          *             'Name' => The name of the subscriber
-         *             'Date' => The date that the subscriber was unsubscribed from the list
+         *             'Date' => The date when the status of subscriber last changed (ie: becomes unsubscribed)   
+         *             'ListJoinedDate' => The date the subscriber was first added to the list
          *             'State' => The current state of the subscriber, will be 'Unsubscribed'
          *             'CustomFields' => array (
          *                 {
@@ -437,7 +441,8 @@ if (!class_exists('CS_REST_Lists')) {
          *         {
          *             'EmailAddress' => The email address of the subscriber
          *             'Name' => The name of the subscriber
-         *             'Date' => The date that the subscriber was deleted from the list
+         *             'Date' => The date when the status of subscriber last changed (ie: becomes deleted)   
+         *             'ListJoinedDate' => The date the subscriber was first added to the list
          *             'State' => The current state of the subscriber, will be 'Deleted'
          *             'CustomFields' => array (
          *                 {

--- a/csrest_segments.php
+++ b/csrest_segments.php
@@ -187,7 +187,8 @@ if (!class_exists('CS_REST_Segments')) {
          *         {
          *             'EmailAddress' => The email address of the subscriber
          *             'Name' => The name of the subscriber
-         *             'Date' => The date that the subscriber was added to the list
+         *             'Date' => The date when the status of subscriber last changed.
+         *             'ListJoinedDate' => The date the subscriber was first added to the list
          *             'State' => The current state of the subscriber, will be 'Active'
          *             'CustomFields' => array (
          *                 {

--- a/csrest_subscribers.php
+++ b/csrest_subscribers.php
@@ -169,7 +169,8 @@ if (!class_exists('CS_REST_Subscribers')) {
          * {
          *     'EmailAddress' => The subscriber email address
          *     'Name' => The subscribers name
-         *     'Date' => The date the subscriber was added to the list
+         *     'Date' => The date when the status of subscriber last changed.
+         *     'ListJoinedDate' => The date the subscriber was first added to the list
          *     'State' => The current state of the subscriber
          *     'CustomFields' => array(
          *         {

--- a/samples/campaign/get_summary.php
+++ b/samples/campaign/get_summary.php
@@ -8,7 +8,7 @@ $auth = array(
 $wrap = new CS_REST_Campaigns('Campaign ID to get the summary of', $auth);
 $result = $wrap->get_summary();
 
-echo "Result of GET /api/v3.1/campaigns/{id}/summary\n<br />";
+echo "Result of GET /api/v3.3/campaigns/{id}/summary\n<br />";
 if($result->was_successful()) {
     echo "Got summary\n<br /><pre>";
     var_dump($result->response);

--- a/samples/client/get_campaigns.php
+++ b/samples/client/get_campaigns.php
@@ -11,7 +11,7 @@ $wrap = new CS_REST_Clients(
 
 $result = $wrap->get_campaigns();
 
-echo "Result of /api/v3.1/clients/{id}/campaigns\n<br />";
+echo "Result of /api/v3.3/clients/{id}/campaigns\n<br />";
 if($result->was_successful()) {
     echo "Got campaigns\n<br /><pre>";
     var_dump($result->response);

--- a/samples/client/get_drafts.php
+++ b/samples/client/get_drafts.php
@@ -11,7 +11,7 @@ $wrap = new CS_REST_Clients(
 
 $result = $wrap->get_drafts();
 
-echo "Result of /api/v3.1/clients/{id}/drafts\n<br />";
+echo "Result of /api/v3.3/clients/{id}/drafts\n<br />";
 if($result->was_successful()) {
     echo "Got drafts\n<br /><pre>";
     var_dump($result->response);

--- a/samples/client/get_scheduled.php
+++ b/samples/client/get_scheduled.php
@@ -11,7 +11,7 @@ $wrap = new CS_REST_Clients(
 
 $result = $wrap->get_scheduled();
 
-echo "Result of /api/v3.1/clients/{id}/scheduled\n<br />";
+echo "Result of /api/v3.3/clients/{id}/scheduled\n<br />";
 if($result->was_successful()) {
     echo "Got scheduled campaigns\n<br /><pre>";
     var_dump($result->response);

--- a/samples/client/get_tags.php
+++ b/samples/client/get_tags.php
@@ -1,0 +1,22 @@
+<?php
+
+require_once '../../csrest_clients.php';
+
+$auth = array(
+    'access_token' => 'your access token',
+    'refresh_token' => 'your refresh token');
+$wrap = new CS_REST_Clients(
+    'ClientID to get Tags for',
+    $auth);
+
+$result = $wrap->get_tags();
+
+echo "Result of /api/v3.3/clients/{id}/tags\n<br />";
+if($result->was_successful()) {
+    echo "Got tags\n<br /><pre>";
+    var_dump($result->response);
+} else {
+    echo 'Failed with code '.$result->http_status_code."\n<br /><pre>";
+    var_dump($result->response);
+}
+echo '</pre>';

--- a/samples/list/get_active_subscribers.php
+++ b/samples/list/get_active_subscribers.php
@@ -13,7 +13,7 @@ $result = $wrap->get_active_subscribers('Added since', 1, 50, 'email', 'asc', tr
 //$result = $wrap->get_active_subscribers(date('Y-m-d', strtotime('-30 days')), 
 //  page number, page size, order by, order direction);
 
-echo "Result of GET /api/v3.1/lists/{ID}/active\n<br />";
+echo "Result of GET /api/v3.3/lists/{ID}/active\n<br />";
 if($result->was_successful()) {
     echo "Got subscribers\n<br /><pre>";
     var_dump($result->response);

--- a/samples/list/get_bounced_subscribers.php
+++ b/samples/list/get_bounced_subscribers.php
@@ -11,7 +11,7 @@ $result = $wrap->get_bounced_subscribers('Bounced Since', 1, 50, 'email', 'asc')
 //$result = $wrap->get_bounced_subscribers(date('Y-m-d', strtotime('-30 days')), 
 //  page number, page size, order by, order direction);
 
-echo "Result of GET /api/v3.1/lists/{ID}/bounced\n<br />";
+echo "Result of GET /api/v3.3/lists/{ID}/bounced\n<br />";
 if($result->was_successful()) {
     echo "Got subscribers\n<br /><pre>";
     var_dump($result->response);

--- a/samples/list/get_deleted_subscribers.php
+++ b/samples/list/get_deleted_subscribers.php
@@ -11,7 +11,7 @@ $result = $wrap->get_deleted_subscribers('Deleted Since', 1, 50, 'email', 'asc')
 //$result = $wrap->get_bounced_subscribers(date('Y-m-d', strtotime('-30 days')), 
 //  page number, page size, order by, order direction);
 
-echo "Result of GET /api/v3.1/lists/{ID}/deleted\n<br />";
+echo "Result of GET /api/v3.3/lists/{ID}/deleted\n<br />";
 if($result->was_successful()) {
     echo "Got subscribers\n<br /><pre>";
     var_dump($result->response);

--- a/samples/list/get_unconfirmed_subscribers.php
+++ b/samples/list/get_unconfirmed_subscribers.php
@@ -11,7 +11,7 @@ $result = $wrap->get_unconfirmed_subscribers('Added since', 1, 50, 'email', 'asc
 //$result = $wrap->get_active_subscribers(date('Y-m-d', strtotime('-30 days')), 
 //  page number, page size, order by, order direction);
 
-echo "Result of GET /api/v3.1/lists/{ID}/unconfirmed\n<br />";
+echo "Result of GET /api/v3.3/lists/{ID}/unconfirmed\n<br />";
 if($result->was_successful()) {
     echo "Got subscribers\n<br /><pre>";
     var_dump($result->response);

--- a/samples/list/get_unsubscribed_subscribers.php
+++ b/samples/list/get_unsubscribed_subscribers.php
@@ -11,7 +11,7 @@ $result = $wrap->get_unsubscribed_subscribers('Unsubscribed Since', 1, 50, 'emai
 //$result = $wrap->get_bounced_subscribers(date('Y-m-d', strtotime('-30 days')), 
 //  page number, page size, order by, order direction);
 
-echo "Result of GET /api/v3.1/lists/{ID}/unsubscribed\n<br />";
+echo "Result of GET /api/v3.3/lists/{ID}/unsubscribed\n<br />";
 if($result->was_successful()) {
     echo "Got subscribers\n<br /><pre>";
     var_dump($result->response);

--- a/samples/segment/get_subscribers.php
+++ b/samples/segment/get_subscribers.php
@@ -13,7 +13,7 @@ $result = $wrap->get_subscribers('Added since', 1, 50, 'email', 'asc', true);
 //$result = $wrap->get_subscribers(date('Y-m-d', strtotime('-30 days')), 
 //  page number, page size, order by, order description);
 
-echo "Result of GET /api/v3.1/segments/{segment id}/active\n<br />";
+echo "Result of GET /api/v3.3/segments/{segment id}/active\n<br />";
 if($result->was_successful()) {
     echo "Got subscribers\n<br /><pre>";
     var_dump($result->response);

--- a/samples/subscriber/get.php
+++ b/samples/subscriber/get.php
@@ -10,7 +10,7 @@ $wrap = new CS_REST_Subscribers('Your list ID', $auth);
 //The 2nd argument will return the tracking preference of the subscriber - 'ConsentToTrack'
 $result = $wrap->get('Email address', true);
 
-echo "Result of GET /api/v3.1/subscribers/{list id}.{format}?email={email}\n<br />";
+echo "Result of GET /api/v3.3/subscribers/{list id}.{format}?email={email}\n<br />";
 if($result->was_successful()) {
     echo "Got subscriber <pre>";
     var_dump($result->response);

--- a/tests/all_tests.php
+++ b/tests/all_tests.php
@@ -3,6 +3,8 @@ require_once __DIR__.'/../vendor/autoload.php';
 require_once __DIR__.'/../vendor/simpletest/simpletest/autorun.php';
 require_once __DIR__.'/../vendor/simpletest/simpletest/mock_objects.php';
 
+// Running simpletest, you would need to run this using PHP version 7.3 or lower
+
 class AllTests extends TestSuite {
     function __construct() {
         parent::__construct('All Tests');

--- a/tests/class_tests/response_tests.php
+++ b/tests/class_tests/response_tests.php
@@ -255,6 +255,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         "EmailAddress" => "subs+7t8787Y@example.com",
                         "Name" => "Person One",
                         "Date" => "2010-10-25 10:28:00",
+                        "ListJoinedDate" => "2010-10-25 10:28:00",
                         "State" => "Active",
                         "CustomFields" => array(
                             array(
@@ -275,6 +276,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         "EmailAddress" => "subs+7878787y8ggg@example.com",
                         "Name" => "Person Two",
                         "Date" => "2010-10-25 12:17:00",
+                        "ListJoinedDate" => "2010-10-25 12:17:00",
                         "State" => "Active",
                         "CustomFields" => array(
                             array(
@@ -287,6 +289,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         "EmailAddress" => "subs+7890909i0ggg@example.com",
                         "Name" => "Person Three",
                         "Date" => "2010-10-25 12:52:00",
+                        "ListJoinedDate" => "2010-10-25 12:52:00",
                         "State" => "Active",
                         "CustomFields" => array(
                             array(
@@ -299,6 +302,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         "EmailAddress" => "subs@example.com",
                         "Name" => "Person Four",
                         "Date" => "2010-10-27 13:13:00",
+                        "ListJoinedDate" => "2010-10-27 13:13:00",
                         "State" => "Active",
                         "CustomFields" => array()
                     ),
@@ -306,6 +310,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         "EmailAddress" => "joey@example.com",
                         "Name" => "Person Five",
                         "Date" => "2010-10-27 13:13:00",
+                        "ListJoinedDate" => "2010-10-27 13:13:00",
                         "State" => "Active",
                         "CustomFields" => array()
                     )
@@ -347,6 +352,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                 'EmailAddress' => 'subscriber@example.com',
                 'Name' => 'Subscriber One',
                 'Date' => '2010-10-25 10:28:00',
+                'ListJoinedDate' => '2010-10-25 10:28:00',
                 'State' => 'Active',
                 'CustomFields' => array(
                     array(
@@ -472,6 +478,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         'EmailAddress' => 'bouncedsubscriber@example.com',
                         'Name' => 'Bounced One',
                         'Date' => '2010-10-25 13:11:00',
+                        'ListJoinedDate' => '2010-10-25 13:11:00',
                         'State' => 'Bounced',
                         'CustomFields' => array()
                     )
@@ -484,12 +491,131 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                 'TotalNumberOfRecords' => 1,
                 'NumberOfPages' => 1
             ),
+            'deleted_subscribers' => array(
+                'Results' => array(
+                    array(
+                        'EmailAddress' => 'subs+7t8787Y@example.com',
+                        'Name' => 'Person One',
+                        'Date' => '2010-10-25 10:28:00',
+                        'ListJoinedDate' => '2010-10-25 10:28:00',
+                        'State' => 'Deleted',
+                        'CustomFields' => array(
+                            array(
+                                "Key" => "website",
+                                "Value" => "http://example.com"
+                            ),
+                            array(
+                                "Key" => "age",
+                                "Value" => "24"
+                            ),
+                            array(
+                                "Key" => "subscription date",
+                                "Value" => "2010-03-09"
+                            ),
+                        ),
+                        'ReadsEmailWith' => 'Gmail'
+                    ),
+                    array(
+                        'EmailAddress' => 'subs+7878787y8ggg@example.com',
+                        'Name' => 'Person Two',
+                        'Date' => '2010-10-25 12:17:00',
+                        'ListJoinedDate' => '2010-10-25 10:28:00',
+                        'State' => 'Deleted',
+                        'CustomFields' => array(
+                            array(
+                                "Key" => "website",
+                                "Value" => "http://subdomain.example.com"
+                            ),
+                        ),
+                        'ReadsEmailWith' => 'Gmail'
+                    ),
+                    array(
+                        'EmailAddress' => 'subs+7890909i0ggg@example.com',
+                        'Name' => 'Person Three',
+                        'Date' => '2010-10-25 12:52:00',
+                        'ListJoinedDate' => '2010-10-25 10:28:00',
+                        'State' => 'Deleted',
+                        'CustomFields' => array(
+                            array(
+                                "Key" => "website",
+                                "Value" => "http://subdomain.example.com"
+                            ),
+                        ),
+                        'ReadsEmailWith' => ''
+                    ),
+                    array(
+                        'EmailAddress' => 'subs@example.com',
+                        'Name' => 'Person Four',
+                        'Date' => '2010-10-27 13:13:00',
+                        'ListJoinedDate' => '2010-10-25 10:28:00',
+                        'State' => 'Deleted',
+                        'CustomFields' => array(),
+                        'ReadsEmailWith' => ''
+                    ),
+                    array(
+                        'EmailAddress' => 'joey@example.com',
+                        'Name' => 'Person Five',
+                        'Date' => '2010-10-27 13:13:00',
+                        'ListJoinedDate' => '2010-10-25 10:28:00',
+                        'State' => 'Deleted',
+                        'CustomFields' => array(),
+                        'ReadsEmailWith' => 'Gmail'
+                    )
+                ),
+                'ResultsOrderedBy' => 'email',
+                'OrderDirection' => 'asc',
+                'PageNumber' => 1,
+                'PageSize' => 1000,
+                'RecordsOnThisPage' => 5,
+                'TotalNumberOfRecords' => 5,
+                'NumberOfPages' => 1
+            ),
+            'unconfirmed_subscribers' => array(
+                'Results' => array(
+                   array(
+                        'EmailAddress' => 'subs+7878787y8ggg@example.com',
+                        'Name' => 'Person Two',
+                        'Date' => '2010-10-25 12:17:00',
+                        'ListJoinedDate' => '2010-10-25 10:28:00',
+                        'State' => 'Unconfirmed',
+                        'CustomFields' => array(
+                            array(
+                                "Key" => "website",
+                                "Value" => "http://subdomain.example.com"
+                            ),
+                        ),
+                        'ReadsEmailWith' => 'Gmail'
+                    ),
+                    array(
+                        'EmailAddress' => 'subs+7890909i0ggg@example.com',
+                        'Name' => 'Person Three',
+                        'Date' => '2010-10-25 12:52:00',
+                        'ListJoinedDate' => '2010-10-25 10:28:00',
+                        'State' => 'Unconfirmed',
+                        'CustomFields' => array(
+                            array(
+                                "Key" => "website",
+                                "Value" => "http://subdomain.example.com"
+                            ),
+                        ),
+                        'ReadsEmailWith' => ''
+                    )
+                ),
+                'ResultsOrderedBy' => 'email',
+                'OrderDirection' => 'asc',
+                'PageNumber' => 1,
+                'PageSize' => 1000,
+                'RecordsOnThisPage' => 2,
+                'TotalNumberOfRecords' => 2,
+                'NumberOfPages' => 1
+            ),
             'unsubscribed_subscribers' => array(
                 "Results" => array(
                     array(
                         "EmailAddress" => "subscriber@example.com",
                         "Name" => "Unsub One",
                         "Date" => "2010-10-25 13:11:00",
+                        "ListJoinedDate" => "2010-10-25 13:11:00",
                         "State" => "Unsubscribed",
                         "CustomFields" => array()
                     ),
@@ -497,6 +623,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         "EmailAddress" => "subscriberone@example.com",
                         "Name" => "Subscriber",
                         "Date" => "2010-10-25 13:04:00",
+                        "ListJoinedDate" => "2010-10-25 13:04:00",
                         "State" => "Unsubscribed",
                         "CustomFields" => array(
                             array(
@@ -509,6 +636,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         "EmailAddress" => "example+1@example.com",
                         "Name" => "Example One",
                         "Date" => "2010-10-26 10:56:00",
+                        "ListJoinedDate" => "2010-10-26 10:56:00",
                         "State" => "Unsubscribed",
                         "CustomFields" => array()
                     ),
@@ -516,6 +644,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         "EmailAddress" => "example+2@example.com",
                         "Name" => "Example Two",
                         "Date" => "2010-10-26 10:56:00",
+                        "ListJoinedDate" => "2010-10-26 10:56:00",
                         "State" => "Unsubscribed",
                         "CustomFields" => array()
                     ),
@@ -523,6 +652,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         "EmailAddress" => "example+3@example.com",
                         "Name" => "Example Three",
                         "Date" => "2010-10-26 10:56:00",
+                        "ListJoinedDate" => "2010-10-26 10:56:00",
                         "State" => "Unsubscribed",
                         "CustomFields" => array()
                     )
@@ -854,6 +984,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         "EmailAddress" => "personone@example.com",
                         "Name" => "Person One",
                         "Date" => "2010-10-27 13:13:00",
+                        "ListJoinedDate" => "2010-10-27 13:13:00",
                         "State" => "Active",
                         "CustomFields" => array()
                     ),
@@ -861,6 +992,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         "EmailAddress" => "persontwo@example.com",
                         "Name" => "Person Two",
                         "Date" => "2010-10-27 13:13:00",
+                        "ListJoinedDate" => "2010-10-27 13:13:00",
                         "State" => "Active",
                         "CustomFields" => array()
                     )
@@ -920,7 +1052,6 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
             $template_responses
         );
     }
-
     
     function do_test_response_deserialisation() {
     	if(!is_null($this->deserialiser)) {

--- a/tests/class_tests/response_tests.php
+++ b/tests/class_tests/response_tests.php
@@ -12,912 +12,912 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
     var $deserialiser;
 
     function setUp() {
-    	$util_responses = array(
-    			'clients' => array(
-    					array(
-    							'ClientID' => '4a397ccaaa55eb4e6aa1221e1e2d7122',
-    							'Name' => 'Client One'
-    					),
-    					array(
-    							'ClientID' => 'a206def0582eec7dae47d937a4109cb2',
-    							'Name' => 'Client Two'
-    					)
-    			),
-    			'apikey' => array(
-    					'ApiKey' => '981298u298ue98u219e8u2e98u2'
-    			),
-    			'systemdate' => array(
-    					'SystemDate' => '2010-10-15 09:27:00'
-    			),
-    			'custom_api_error' => array(
-    					'Code' => 98798,
-    					'Message' => 'A crazy API error'
-    			),
-    			'countries' => array(
-    					"Afghanistan",
-    					"Albania",
-    					"Algeria",
-    					"American Samoa",
-    					"Andorra",
-    					"Angola",
-    					"Anguilla",
-    					"Antigua & Barbuda",
-    					"Argentina"
-    			),
-    			'timezones' => array(
-    					"(GMT) Casablanca",
-    					"(GMT) Coordinated Universal Time",
-    					"(GMT) Greenwich Mean Time : Dublin, Edinburgh, Lisbon, London",
-    					"(GMT) Monrovia, Reykjavik",
-    					"(GMT+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna",
-    					"(GMT+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague",
-    					"(GMT+01:00) Brussels, Copenhagen, Madrid, Paris"
-    			)
-    	);
+        $util_responses = array(
+            'clients' => array(
+                array(
+                    'ClientID' => '4a397ccaaa55eb4e6aa1221e1e2d7122',
+                    'Name' => 'Client One'
+                ),
+                array(
+                    'ClientID' => 'a206def0582eec7dae47d937a4109cb2',
+                    'Name' => 'Client Two'
+                )
+            ),
+            'apikey' => array(
+                'ApiKey' => '981298u298ue98u219e8u2e98u2'
+            ),
+            'systemdate' => array(
+                'SystemDate' => '2010-10-15 09:27:00'
+            ),
+            'custom_api_error' => array(
+                'Code' => 98798,
+                'Message' => 'A crazy API error'
+            ),
+            'countries' => array(
+                "Afghanistan",
+                "Albania",
+                "Algeria",
+                "American Samoa",
+                "Andorra",
+                "Angola",
+                "Anguilla",
+                "Antigua & Barbuda",
+                "Argentina"
+            ),
+            'timezones' => array(
+                "(GMT) Casablanca",
+                "(GMT) Coordinated Universal Time",
+                "(GMT) Greenwich Mean Time : Dublin, Edinburgh, Lisbon, London",
+                "(GMT) Monrovia, Reykjavik",
+                "(GMT+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna",
+                "(GMT+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague",
+                "(GMT+01:00) Brussels, Copenhagen, Madrid, Paris"
+            )
+        );
 
-    	$client_responses = array(
-    			'client_details' => array(
-    					'ApiKey' => '7c86c29e930f4a1c3836eb57e9e3f4b283b06857489a750e',
-    					'BasicDetails' => array(
-    							'ClientID' => '4a397ccaaa55eb4e6aa1221e1e2d7122',
-    							'CompanyName' => 'Client One',
-    							'Country' => 'Australia',
-    							'TimeZone' => '(GMT+10:00) Canberra, Melbourne, Sydney'
-    					),
-    					'BillingDetails' => array(
-    							'CanPurchaseCredits' => true,
-    							'MarkupOnDesignSpamTest' => 0,
-    							'ClientPays' => true,
-    							'BaseRatePerRecipient' => 1,
-    							'MarkupPerRecipient' => 0,
-    							'MarkupOnDelivery' => 0,
-    							'BaseDeliveryRate' => 5,
-    							'Currency' => 'USD',
-    							'BaseDesignSpamTestRate' => 5
-    					)
-    			),
-    			'create_client' => '32a381c49a2df99f1d0c6f3c112352b9',
+        $client_responses = array(
+            'client_details' => array(
+                'ApiKey' => '7c86c29e930f4a1c3836eb57e9e3f4b283b06857489a750e',
+                'BasicDetails' => array(
+                    'ClientID' => '4a397ccaaa55eb4e6aa1221e1e2d7122',
+                    'CompanyName' => 'Client One',
+                    'Country' => 'Australia',
+                    'TimeZone' => '(GMT+10:00) Canberra, Melbourne, Sydney'
+                ),
+                'BillingDetails' => array(
+                    'CanPurchaseCredits' => true,
+                    'MarkupOnDesignSpamTest' => 0,
+                    'ClientPays' => true,
+                    'BaseRatePerRecipient' => 1,
+                    'MarkupPerRecipient' => 0,
+                    'MarkupOnDelivery' => 0,
+                    'BaseDeliveryRate' => 5,
+                    'Currency' => 'USD',
+                    'BaseDesignSpamTestRate' => 5
+                )
+            ),
+            'create_client' => '32a381c49a2df99f1d0c6f3c112352b9',
 
-                'campaigns' => array(
-                    'Results' => array(
-                        array(
-                            'WebVersionURL' => 'http://hello.createsend.com/t/ViewEmail/r/765E86829575EE2C/C67FD2F38AC4859C/',
-                            'WebVersionTextURL' => 'http://createsend.com/t/r-765E86829575EE2C/t',
-                            'CampaignID' => 'fc0ce7105baeaf97f47c99be31d02a91',
-                            'Subject' => 'Campaign One',
-                            'Name' => 'Campaign One',
-                            'FromName' => 'My Name',
-                            'FromEmail' => 'myemail@example.com',
-                            'ReplyTo' => 'myemail@example.com',
-                            'SentDate' => '2010-10-12 12:58:00',
-                            'TotalRecipients' => 2245,
-                            'Tags' => array(
-                                'Tag1', 'Tag2'
-                            )
-                        ),
-                        array(
-                            'WebVersionURL' => 'http://hello.createsend.com/t/ViewEmail/r/DD543566A87C9B8B/C67FD2F38AC4859C/',
-                            'WebVersionTextURL' => 'http://createsend.com/t/r-DD543566A87C9B8B/t',
-                            'CampaignID' => '072472b88c853ae5dedaeaf549a8d607',
-                            'Subject' => 'Campaign Two',
-                            'Name' => 'Campaign Two',
-                            'FromName' => 'My Name',
-                            'FromEmail' => 'myemail@example.com',
-                            'ReplyTo' => 'myemail@example.com',
-                            'SentDate' => '2010-10-06 16:20:00',
-                            'TotalRecipients' => 11222
+            'campaigns' => array(
+                'Results' => array(
+                    array(
+                        'WebVersionURL' => 'http://hello.createsend.com/t/ViewEmail/r/765E86829575EE2C/C67FD2F38AC4859C/',
+                        'WebVersionTextURL' => 'http://createsend.com/t/r-765E86829575EE2C/t',
+                        'CampaignID' => 'fc0ce7105baeaf97f47c99be31d02a91',
+                        'Subject' => 'Campaign One',
+                        'Name' => 'Campaign One',
+                        'FromName' => 'My Name',
+                        'FromEmail' => 'myemail@example.com',
+                        'ReplyTo' => 'myemail@example.com',
+                        'SentDate' => '2010-10-12 12:58:00',
+                        'TotalRecipients' => 2245,
+                        'Tags' => array(
+                            'Tag1', 'Tag2'
                         )
                     ),
-                    'ResultsOrderedBy' => 'SentDate',
-                    'OrderDirection' => "desc",
-                    'PageNumber' => 1,
-                    'PageSize' => 2,
-                    'RecordsOnThisPage' => 2,
-                    'TotalNumberOfRecords' => 49,
-                    'NumberOfPages' => 25
-                ),
-    			'scheduled' => array(
-    					array(
-    							"DateScheduled" => "2011-05-25 10:40:00",
-    							"ScheduledTimeZone" => "(GMT+10:00) Canberra, Melbourne, Sydney",
-    							"CampaignID" => "827dbbd2161ea9989fa11ad562c66937",
-    							"Name" => "Magic Issue One",
-    							"Subject" => "Magic Issue One",
-                  'FromName' => 'My Name',
-                  'FromEmail' => 'myemail@example.com',
-                  'ReplyTo' => 'myemail@example.com',
-    							"DateCreated" => "2011-05-24 10:37:00",
-    							"PreviewURL" => "http://createsend.com/t/r-DD543521A87C9B8B",
-  							  "PreviewTextURL" => "http://createsend.com/t/r-DD543521A87C9B8B/t",
-                            "Tags" => array("Tag1", "Tag2")
-    					),
-    					array(
-    							"DateScheduled" => "2011-05-29 11:20:00",
-    							"ScheduledTimeZone" => "(GMT+10:00) Canberra, Melbourne, Sydney",
-    							"CampaignID" => "4f54bbd2161e65789fa11ad562c66937",
-    							"Name" => "Magic Issue Two",
-    							"Subject" => "Magic Issue Two",
-                  'FromName' => 'My Name',
-                  'FromEmail' => 'myemail@example.com',
-                  'ReplyTo' => 'myemail@example.com',
-    							"DateCreated" => "2011-05-24 10:39:00",
-    							"PreviewURL" => "http://createsend.com/t/r-DD913521A87C9B8B",
-    							"PreviewTextURL" => "http://createsend.com/t/r-DD913521A87C9B8B/t",
-                            "Tags" => array()
-    					)
-    			),
-    			'drafts' => array(
-    					array(
-    							"CampaignID" => "7c7424792065d92627139208c8c01db1",
-    							"Name" => "Draft One",
-    							"Subject" => "Draft One",
-                  'FromName' => 'My Name',
-                  'FromEmail' => 'myemail@example.com',
-                  'ReplyTo' => 'myemail@example.com',
-    							"DateCreated" => "2010-08-19 16:08:00",
-    							"PreviewURL" => "http://hello.createsend.com/t/ViewEmail/r/E97A7BB2E6983DA1/C67FD2F38AC4859C/",
-    							"PreviewTextURL" => "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
-                            "Tags" => array()
-    					),
-    					array(
-    							"CampaignID" => "2e928e982065d92627139208c8c01db1",
-    							"Name" => "Draft Two",
-    							"Subject" => "Draft Two",
-                  'FromName' => 'My Name',
-                  'FromEmail' => 'myemail@example.com',
-                  'ReplyTo' => 'myemail@example.com',
-    							"DateCreated" => "2010-08-19 16:08:00",
-    							"PreviewURL" => "http://hello.createsend.com/t/ViewEmail/r/E97A7BB2E6983DA1/C67FD2F38AC4859C/",
-    							"PreviewTextURL" => "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
-                            "Tags" => array("Tag1", "Tag2")
-    					)
-    			),
-    			'lists' => array(
-    					array(
-    							"ListID" => "a58ee1d3039b8bec838e6d1482a8a965",
-    							"Name" => "List One"
-    					),
-    					array(
-    							"ListID" => "99bc35084a5739127a8ab81eae5bd305",
-    							"Name" => "List Two"
-    					)
-    			),
-    			'segments' => array(
-    					array(
-    							'ListID' => 'a58ee1d3039b8bec838e6d1482a8a965',
-    							'SegmentID' => '46aa5e01fd43381863d4e42cf277d3a9',
-    							'Title' => 'Segment One'
-    					),
-    					array(
-    							'ListID' => '8dffb94c60c5faa3d40f496f2aa58a8a',
-    							'SegmentID' => 'dhw9q8jd9q8wd09quw0d909wid9i09iq',
-    							'Title' => 'Segment Two'
-    					)
-    			),
-    			'suppressionlist' => array(
-    					"Results" => array(
-    							array(
-    									"SuppressionReason" => "Unsubscribed",
-    									"EmailAddress" => "example+1@example.com",
-    									"Date" => "2010-10-26 10:55:31",
-    									"State" => "Suppressed"
-    							),
-    							array(
-    									"SuppressionReason" => "Unsubscribed",
-    									"EmailAddress" => "example+2@example.com",
-    									"Date" => "2010-10-26 10:55:31",
-    									"State" => "Suppressed"
-    							),
-    							array(
-    									"SuppressionReason" => "Unsubscribed",
-    									"EmailAddress" => "example+3@example.com",
-    									"Date" => "2010-10-26 10:55:31",
-    									"State" => "Suppressed"
-    							),
-    							array(
-    									"SuppressionReason" => "Unsubscribed",
-    									"EmailAddress" => "subscriber@example.com",
-    									"Date" => "2010-10-25 13:11:04",
-    									"State" => "Suppressed"
-    							),
-    							array(
-    									"SuppressionReason" => "Unsubscribed",
-    									"EmailAddress" => "subscriberone@example.com",
-    									"Date" => "2010-10-25 13:04:15",
-    									"State" => "Suppressed"
-    							)
-    					),
-    					"ResultsOrderedBy" => "email",
-    					"OrderDirection" => "asc",
-    					"PageNumber" => 1,
-    					"PageSize" => 1000,
-    					"RecordsOnThisPage" => 5,
-    					"TotalNumberOfRecords" => 5,
-    					"NumberOfPages" => 1
-    			),
-                'tags' => array(
                     array(
-                        'Name' => 'Tag One',
-                        'NumberOfCampaigns' => 120,
+                        'WebVersionURL' => 'http://hello.createsend.com/t/ViewEmail/r/DD543566A87C9B8B/C67FD2F38AC4859C/',
+                        'WebVersionTextURL' => 'http://createsend.com/t/r-DD543566A87C9B8B/t',
+                        'CampaignID' => '072472b88c853ae5dedaeaf549a8d607',
+                        'Subject' => 'Campaign Two',
+                        'Name' => 'Campaign Two',
+                        'FromName' => 'My Name',
+                        'FromEmail' => 'myemail@example.com',
+                        'ReplyTo' => 'myemail@example.com',
+                        'SentDate' => '2010-10-06 16:20:00',
+                        'TotalRecipients' => 11222
+                    )
+                ),
+                'ResultsOrderedBy' => 'SentDate',
+                'OrderDirection' => "desc",
+                'PageNumber' => 1,
+                'PageSize' => 2,
+                'RecordsOnThisPage' => 2,
+                'TotalNumberOfRecords' => 49,
+                'NumberOfPages' => 25
+            ),
+            'scheduled' => array(
+                array(
+                    "DateScheduled" => "2011-05-25 10:40:00",
+                    "ScheduledTimeZone" => "(GMT+10:00) Canberra, Melbourne, Sydney",
+                    "CampaignID" => "827dbbd2161ea9989fa11ad562c66937",
+                    "Name" => "Magic Issue One",
+                    "Subject" => "Magic Issue One",
+                    'FromName' => 'My Name',
+                    'FromEmail' => 'myemail@example.com',
+                    'ReplyTo' => 'myemail@example.com',
+                    "DateCreated" => "2011-05-24 10:37:00",
+                    "PreviewURL" => "http://createsend.com/t/r-DD543521A87C9B8B",
+                    "PreviewTextURL" => "http://createsend.com/t/r-DD543521A87C9B8B/t",
+                    "Tags" => array("Tag1", "Tag2")
+                ),
+                array(
+                    "DateScheduled" => "2011-05-29 11:20:00",
+                    "ScheduledTimeZone" => "(GMT+10:00) Canberra, Melbourne, Sydney",
+                    "CampaignID" => "4f54bbd2161e65789fa11ad562c66937",
+                    "Name" => "Magic Issue Two",
+                    "Subject" => "Magic Issue Two",
+                    'FromName' => 'My Name',
+                    'FromEmail' => 'myemail@example.com',
+                    'ReplyTo' => 'myemail@example.com',
+                    "DateCreated" => "2011-05-24 10:39:00",
+                    "PreviewURL" => "http://createsend.com/t/r-DD913521A87C9B8B",
+                    "PreviewTextURL" => "http://createsend.com/t/r-DD913521A87C9B8B/t",
+                    "Tags" => array()
+                )
+            ),
+            'drafts' => array(
+                array(
+                    "CampaignID" => "7c7424792065d92627139208c8c01db1",
+                    "Name" => "Draft One",
+                    "Subject" => "Draft One",
+                    'FromName' => 'My Name',
+                    'FromEmail' => 'myemail@example.com',
+                    'ReplyTo' => 'myemail@example.com',
+                    "DateCreated" => "2010-08-19 16:08:00",
+                    "PreviewURL" => "http://hello.createsend.com/t/ViewEmail/r/E97A7BB2E6983DA1/C67FD2F38AC4859C/",
+                    "PreviewTextURL" => "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
+                    "Tags" => array()
+                ),
+                array(
+                    "CampaignID" => "2e928e982065d92627139208c8c01db1",
+                    "Name" => "Draft Two",
+                    "Subject" => "Draft Two",
+                    'FromName' => 'My Name',
+                    'FromEmail' => 'myemail@example.com',
+                    'ReplyTo' => 'myemail@example.com',
+                    "DateCreated" => "2010-08-19 16:08:00",
+                    "PreviewURL" => "http://hello.createsend.com/t/ViewEmail/r/E97A7BB2E6983DA1/C67FD2F38AC4859C/",
+                    "PreviewTextURL" => "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
+                    "Tags" => array("Tag1", "Tag2")
+                )
+            ),
+            'lists' => array(
+                array(
+                    "ListID" => "a58ee1d3039b8bec838e6d1482a8a965",
+                    "Name" => "List One"
+                ),
+                array(
+                    "ListID" => "99bc35084a5739127a8ab81eae5bd305",
+                    "Name" => "List Two"
+                )
+            ),
+            'segments' => array(
+                array(
+                    'ListID' => 'a58ee1d3039b8bec838e6d1482a8a965',
+                    'SegmentID' => '46aa5e01fd43381863d4e42cf277d3a9',
+                    'Title' => 'Segment One'
+                ),
+                array(
+                    'ListID' => '8dffb94c60c5faa3d40f496f2aa58a8a',
+                    'SegmentID' => 'dhw9q8jd9q8wd09quw0d909wid9i09iq',
+                    'Title' => 'Segment Two'
+                )
+            ),
+            'suppressionlist' => array(
+                "Results" => array(
+                    array(
+                        "SuppressionReason" => "Unsubscribed",
+                        "EmailAddress" => "example+1@example.com",
+                        "Date" => "2010-10-26 10:55:31",
+                        "State" => "Suppressed"
                     ),
                     array(
-                        'Name' => 'Tag Two',
-                        'NumberOfCampaigns' => 62,
+                        "SuppressionReason" => "Unsubscribed",
+                        "EmailAddress" => "example+2@example.com",
+                        "Date" => "2010-10-26 10:55:31",
+                        "State" => "Suppressed"
+                    ),
+                    array(
+                        "SuppressionReason" => "Unsubscribed",
+                        "EmailAddress" => "example+3@example.com",
+                        "Date" => "2010-10-26 10:55:31",
+                        "State" => "Suppressed"
+                    ),
+                    array(
+                        "SuppressionReason" => "Unsubscribed",
+                        "EmailAddress" => "subscriber@example.com",
+                        "Date" => "2010-10-25 13:11:04",
+                        "State" => "Suppressed"
+                    ),
+                    array(
+                        "SuppressionReason" => "Unsubscribed",
+                        "EmailAddress" => "subscriberone@example.com",
+                        "Date" => "2010-10-25 13:04:15",
+                        "State" => "Suppressed"
+                    )
+                ),
+                "ResultsOrderedBy" => "email",
+                "OrderDirection" => "asc",
+                "PageNumber" => 1,
+                "PageSize" => 1000,
+                "RecordsOnThisPage" => 5,
+                "TotalNumberOfRecords" => 5,
+                "NumberOfPages" => 1
+            ),
+            'tags' => array(
+                array(
+                    'Name' => 'Tag One',
+                    'NumberOfCampaigns' => 120,
+                ),
+                array(
+                    'Name' => 'Tag Two',
+                    'NumberOfCampaigns' => 62,
+                )
+            )
+        );
+
+        $subscriber_responses = array(
+            'active_subscribers' => array(
+                "Results" => array(
+                    array(
+                        "EmailAddress" => "subs+7t8787Y@example.com",
+                        "Name" => "Person One",
+                        "Date" => "2010-10-25 10:28:00",
+                        "State" => "Active",
+                        "CustomFields" => array(
+                            array(
+                                "Key" => "website",
+                                "Value" => "http://example.com"
+                            ),
+                            array(
+                                "Key" => "age",
+                                "Value" => "24"
+                            ),
+                            array(
+                                "Key" => "subscription date",
+                                "Value" => "2010-03-09"
+                            )
+                        )
+                    ),
+                    array(
+                        "EmailAddress" => "subs+7878787y8ggg@example.com",
+                        "Name" => "Person Two",
+                        "Date" => "2010-10-25 12:17:00",
+                        "State" => "Active",
+                        "CustomFields" => array(
+                            array(
+                                "Key" => "website",
+                                "Value" => "http://subdomain.example.com"
+                            )
+                        )
+                    ),
+                    array(
+                        "EmailAddress" => "subs+7890909i0ggg@example.com",
+                        "Name" => "Person Three",
+                        "Date" => "2010-10-25 12:52:00",
+                        "State" => "Active",
+                        "CustomFields" => array(
+                            array(
+                                "Key" => "website",
+                                "Value" => "http://subdomain.example.com"
+                            )
+                        )
+                    ),
+                    array(
+                        "EmailAddress" => "subs@example.com",
+                        "Name" => "Person Four",
+                        "Date" => "2010-10-27 13:13:00",
+                        "State" => "Active",
+                        "CustomFields" => array()
+                    ),
+                    array(
+                        "EmailAddress" => "joey@example.com",
+                        "Name" => "Person Five",
+                        "Date" => "2010-10-27 13:13:00",
+                        "State" => "Active",
+                        "CustomFields" => array()
+                    )
+                ),
+                "ResultsOrderedBy" => "email",
+                "OrderDirection" => "asc",
+                "PageNumber" => 1,
+                "PageSize" => 1000,
+                "RecordsOnThisPage" => 5,
+                "TotalNumberOfRecords" => 5,
+                "NumberOfPages" => 1
+            ),
+            'add_subscriber' => 'subscriber@example.com',
+            'import_subscribers' => array(
+                'FailureDetails' => array(),
+                'TotalUniqueEmailsSubmitted' => 3,
+                'TotalExistingSubscribers' => 0,
+                'TotalNewSubscribers' => 3,
+                'DuplicateEmailsInSubmission' => array()
+            ),
+            'import_subscribers_partial_success' => array(
+                "ResultData" => array(
+                    "TotalUniqueEmailsSubmitted" => 3,
+                    "TotalExistingSubscribers" => 2,
+                    "TotalNewSubscribers" => 0,
+                    "DuplicateEmailsInSubmission" => array(),
+                    "FailureDetails" => array(
+                        array(
+                            "EmailAddress" => "example+1@example",
+                            "Code" => 1,
+                            "Message" => "Invalid Email Address"
+                        )
+                    )
+                ),
+                "Code" => 210,
+                "Message" => "Subscriber Import had some failures"
+            ),
+            'subscriber_details' => array(
+                'EmailAddress' => 'subscriber@example.com',
+                'Name' => 'Subscriber One',
+                'Date' => '2010-10-25 10:28:00',
+                'State' => 'Active',
+                'CustomFields' => array(
+                    array(
+                        'Key' => 'website',
+                        'Value' => 'http://example.com'
+                    ),
+                    array(
+                        'Key' => 'age',
+                        'Value' => '24'
+                    ),
+                    array(
+                        'Key' => 'subscription date',
+                        'Value' => '2010-03-09'
                     )
                 )
-    	);
+            ),
+            'subscriber_history' => array(
+                array(
+                    'ID' => 'fc0ce7105baeaf97f47c99be31d02a91',
+                    'Type' => 'Campaign',
+                    'Name' => 'Campaign One',
+                    'Actions' => array(
+                        array(
+                            'Event' => 'Open',
+                            'Date' => '2010-10-12 13:18:00',
+                            'IPAddress' => '192.168.126.87',
+                            'Detail' => ''
+                        ),
+                        array(
+                            'Event' => 'Click',
+                            'Date' => '2010-10-12 13:16:00',
+                            'IPAddress' => '192.168.126.87',
+                            'Detail' => 'http://example.com/post/12323/'
+                        ),
+                        array(
+                            'Event' => 'Click',
+                            'Date' => '2010-10-12 13:15:00',
+                            'IPAddress' => '192.168.126.87',
+                            'Detail' => 'http://example.com/post/29889/'
+                        ),
+                        array(
+                            'Event' => 'Open',
+                            'Date' => '2010-10-12 13:15:00',
+                            'IPAddress' => '192.168.126.87',
+                            'Detail' => ''
+                        ),
+                        array(
+                            'Event' => 'Click',
+                            'Date' => '2010-10-12 13:01:00',
+                            'IPAddress' => '192.168.126.87',
+                            'Detail' => 'http://example.com/post/82211/'
+                        ),
+                        array(
+                            'Event' => 'Open',
+                            'Date' => '2010-10-12 13:01:00',
+                            'IPAddress' => '192.168.126.87',
+                            'Detail' => ''
+                        )
+                    )
+                )
+            )
+        );
 
-    	$subscriber_responses = array(
-    			'active_subscribers' => array(
-    					"Results" => array(
-    							array(
-    									"EmailAddress" => "subs+7t8787Y@example.com",
-    									"Name" => "Person One",
-    									"Date" => "2010-10-25 10:28:00",
-    									"State" => "Active",
-    									"CustomFields" => array(
-    											array(
-    													"Key" => "website",
-    													"Value" => "http://example.com"
-    											),
-    											array(
-    													"Key" => "age",
-    													"Value" => "24"
-    											),
-    											array(
-    													"Key" => "subscription date",
-    													"Value" => "2010-03-09"
-    											)
-    									)
-    							),
-    							array(
-    									"EmailAddress" => "subs+7878787y8ggg@example.com",
-    									"Name" => "Person Two",
-    									"Date" => "2010-10-25 12:17:00",
-    									"State" => "Active",
-    									"CustomFields" => array(
-    											array(
-    													"Key" => "website",
-    													"Value" => "http://subdomain.example.com"
-    											)
-    									)
-    							),
-    							array(
-    									"EmailAddress" => "subs+7890909i0ggg@example.com",
-    									"Name" => "Person Three",
-    									"Date" => "2010-10-25 12:52:00",
-    									"State" => "Active",
-    									"CustomFields" => array(
-    											array(
-    													"Key" => "website",
-    													"Value" => "http://subdomain.example.com"
-    											)
-    									)
-    							),
-    							array(
-    									"EmailAddress" => "subs@example.com",
-    									"Name" => "Person Four",
-    									"Date" => "2010-10-27 13:13:00",
-    									"State" => "Active",
-    									"CustomFields" => array()
-    							),
-    							array(
-    									"EmailAddress" => "joey@example.com",
-    									"Name" => "Person Five",
-    									"Date" => "2010-10-27 13:13:00",
-    									"State" => "Active",
-    									"CustomFields" => array()
-    							)
-    					),
-    					"ResultsOrderedBy" => "email",
-    					"OrderDirection" => "asc",
-    					"PageNumber" => 1,
-    					"PageSize" => 1000,
-    					"RecordsOnThisPage" => 5,
-    					"TotalNumberOfRecords" => 5,
-    					"NumberOfPages" => 1
-    			),
-    			'add_subscriber' => 'subscriber@example.com',
-    			'import_subscribers' => array(
-    					'FailureDetails' => array(),
-    					'TotalUniqueEmailsSubmitted' => 3,
-    					'TotalExistingSubscribers' => 0,
-    					'TotalNewSubscribers' => 3,
-    					'DuplicateEmailsInSubmission' => array()
-    			),
-    			'import_subscribers_partial_success' => array(
-    					"ResultData" => array(
-    							"TotalUniqueEmailsSubmitted" => 3,
-    							"TotalExistingSubscribers" => 2,
-    							"TotalNewSubscribers" => 0,
-    							"DuplicateEmailsInSubmission" => array(),
-    							"FailureDetails" => array(
-    									array(
-    											"EmailAddress" => "example+1@example",
-    											"Code" => 1,
-    											"Message" => "Invalid Email Address"
-    									)
-    							)
-    					),
-    					"Code" => 210,
-    					"Message" => "Subscriber Import had some failures"
-    			),
-    			'subscriber_details' => array(
-    					'EmailAddress' => 'subscriber@example.com',
-    					'Name' => 'Subscriber One',
-    					'Date' => '2010-10-25 10:28:00',
-    					'State' => 'Active',
-    					'CustomFields' => array(
-    							array(
-    									'Key' => 'website',
-    									'Value' => 'http://example.com'
-    							),
-    							array(
-    									'Key' => 'age',
-    									'Value' => '24'
-    							),
-    							array(
-    									'Key' => 'subscription date',
-    									'Value' => '2010-03-09'
-    							)
-    					)
-    			),
-    			'subscriber_history' => array(
-    					array(
-    							'ID' => 'fc0ce7105baeaf97f47c99be31d02a91',
-    							'Type' => 'Campaign',
-    							'Name' => 'Campaign One',
-    							'Actions' => array(
-    									array(
-    											'Event' => 'Open',
-    											'Date' => '2010-10-12 13:18:00',
-    											'IPAddress' => '192.168.126.87',
-    											'Detail' => ''
-    									),
-    									array(
-    											'Event' => 'Click',
-    											'Date' => '2010-10-12 13:16:00',
-    											'IPAddress' => '192.168.126.87',
-    											'Detail' => 'http://example.com/post/12323/'
-    									),
-    									array(
-    											'Event' => 'Click',
-    											'Date' => '2010-10-12 13:15:00',
-    											'IPAddress' => '192.168.126.87',
-    											'Detail' => 'http://example.com/post/29889/'
-    									),
-    									array(
-    											'Event' => 'Open',
-    											'Date' => '2010-10-12 13:15:00',
-    											'IPAddress' => '192.168.126.87',
-    											'Detail' => ''
-    									),
-    									array(
-    											'Event' => 'Click',
-    											'Date' => '2010-10-12 13:01:00',
-    											'IPAddress' => '192.168.126.87',
-    											'Detail' => 'http://example.com/post/82211/'
-    									),
-    									array(
-    											'Event' => 'Open',
-    											'Date' => '2010-10-12 13:01:00',
-    											'IPAddress' => '192.168.126.87',
-    											'Detail' => ''
-    									)
-    							)
-    					)
-    			)
-    	);
+        $list_responses = array (
+            'custom_fields' => array(
+                array(
+                    "FieldName" => "website",
+                    "Key" => "[website]",
+                    "DataType" => "Text",
+                    "FieldOptions" => array()
+                ),
+                array(
+                    "FieldName" => "age",
+                    "Key" => "[age]",
+                    "DataType" => "Number",
+                    "FieldOptions" => array()
+                ),
+                array(
+                    "FieldName" => "subscription date",
+                    "Key" => "[subscriptiondate]",
+                    "DataType" => "Date",
+                    "FieldOptions" => array()
+                )
+            ),
+            'create_list' => 'e3c5f034d68744f7881fdccf13c2daee',
+            'create_custom_field' => '[newdatefield]',
+            'list_details' => array(
+                'ConfirmedOptIn' => false,
+                'Title' => 'a non-basic list :)',
+                'UnsubscribePage' => '',
+                'ListID' => '2fe4c8f0373ce320e2200596d7ef168f',
+                'ConfirmationSuccessPage' => ''
+            ),
+            'list_stats' => array(
+                "TotalActiveSubscribers" => 6,
+                "NewActiveSubscribersToday" => 0,
+                "NewActiveSubscribersYesterday" => 8,
+                "NewActiveSubscribersThisWeek" => 8,
+                "NewActiveSubscribersThisMonth" => 8,
+                "NewActiveSubscribersThisYear" => 8,
+                "TotalUnsubscribes" => 2,
+                "UnsubscribesToday" => 0,
+                "UnsubscribesYesterday" => 2,
+                "UnsubscribesThisWeek" => 2,
+                "UnsubscribesThisMonth" => 2,
+                "UnsubscribesThisYear" => 2,
+                "TotalDeleted" => 0,
+                "DeletedToday" => 0,
+                "DeletedYesterday" => 0,
+                "DeletedThisWeek" => 0,
+                "DeletedThisMonth" => 0,
+                "DeletedThisYear" => 0,
+                "TotalBounces" => 0,
+                "BouncesToday" => 0,
+                "BouncesYesterday" => 0,
+                "BouncesThisWeek" => 0,
+                "BouncesThisMonth" => 0,
+                "BouncesThisYear" => 0
+            ),
+            'bounced_subscribers' => array(
+                'Results' => array(
+                    array(
+                        'EmailAddress' => 'bouncedsubscriber@example.com',
+                        'Name' => 'Bounced One',
+                        'Date' => '2010-10-25 13:11:00',
+                        'State' => 'Bounced',
+                        'CustomFields' => array()
+                    )
+                ),
+                'ResultsOrderedBy' => 'email',
+                'OrderDirection' => 'asc',
+                'PageNumber' => 1,
+                'PageSize' => 1000,
+                'RecordsOnThisPage' => 1,
+                'TotalNumberOfRecords' => 1,
+                'NumberOfPages' => 1
+            ),
+            'unsubscribed_subscribers' => array(
+                "Results" => array(
+                    array(
+                        "EmailAddress" => "subscriber@example.com",
+                        "Name" => "Unsub One",
+                        "Date" => "2010-10-25 13:11:00",
+                        "State" => "Unsubscribed",
+                        "CustomFields" => array()
+                    ),
+                    array(
+                        "EmailAddress" => "subscriberone@example.com",
+                        "Name" => "Subscriber",
+                        "Date" => "2010-10-25 13:04:00",
+                        "State" => "Unsubscribed",
+                        "CustomFields" => array(
+                            array(
+                                "Key" => "website",
+                                "Value" => "http://google.com"
+                            )
+                        )
+                    ),
+                    array(
+                        "EmailAddress" => "example+1@example.com",
+                        "Name" => "Example One",
+                        "Date" => "2010-10-26 10:56:00",
+                        "State" => "Unsubscribed",
+                        "CustomFields" => array()
+                    ),
+                    array(
+                        "EmailAddress" => "example+2@example.com",
+                        "Name" => "Example Two",
+                        "Date" => "2010-10-26 10:56:00",
+                        "State" => "Unsubscribed",
+                        "CustomFields" => array()
+                    ),
+                    array(
+                        "EmailAddress" => "example+3@example.com",
+                        "Name" => "Example Three",
+                        "Date" => "2010-10-26 10:56:00",
+                        "State" => "Unsubscribed",
+                        "CustomFields" => array()
+                    )
+                ),
+                "ResultsOrderedBy" => "email",
+                "OrderDirection" => "asc",
+                "PageNumber" => 1,
+                "PageSize" => 1000,
+                "RecordsOnThisPage" => 5,
+                "TotalNumberOfRecords" => 5,
+                "NumberOfPages" => 1
+            ),
+            'list_webhooks' => array(
+                array(
+                    "WebhookID" => "943678317049bc13",
+                    "Events" => array(
+                        "Bounce",
+                        "Spam"
+                    ),
+                    "Url" => "http://www.postbin.org/d9w8ud9wud9w",
+                    "Status" => "Active",
+                    "PayloadFormat" => "Json"
+                ),
+                array(
+                    "WebhookID" => "ee1b3864e5ca6161",
+                    "Events" => array(
+                        "Subscribe"
+                    ),
+                    "Url" => "http://www.postbin.org/hiuhiu2h2u",
+                    "Status" => "Active",
+                    "PayloadFormat" => "Xml"
+                )
+            ),
+            'create_list_webhook' => '6a783d359bd44ef62c6ca0d3eda4412a'
+        );
 
-    	$list_responses = array (
-    			'custom_fields' => array(
-    					array(
-    							"FieldName" => "website",
-    							"Key" => "[website]",
-    							"DataType" => "Text",
-    							"FieldOptions" => array()
-    					),
-    					array(
-    							"FieldName" => "age",
-    							"Key" => "[age]",
-    							"DataType" => "Number",
-    							"FieldOptions" => array()
-    					),
-    					array(
-    							"FieldName" => "subscription date",
-    							"Key" => "[subscriptiondate]",
-    							"DataType" => "Date",
-    							"FieldOptions" => array()
-    					)
-    			),
-    			'create_list' => 'e3c5f034d68744f7881fdccf13c2daee',
-    			'create_custom_field' => '[newdatefield]',
-    			'list_details' => array(
-    					'ConfirmedOptIn' => false,
-    					'Title' => 'a non-basic list :)',
-    					'UnsubscribePage' => '',
-    					'ListID' => '2fe4c8f0373ce320e2200596d7ef168f',
-    					'ConfirmationSuccessPage' => ''
-    			),
-    			'list_stats' => array(
-    					"TotalActiveSubscribers" => 6,
-    					"NewActiveSubscribersToday" => 0,
-    					"NewActiveSubscribersYesterday" => 8,
-    					"NewActiveSubscribersThisWeek" => 8,
-    					"NewActiveSubscribersThisMonth" => 8,
-    					"NewActiveSubscribersThisYear" => 8,
-    					"TotalUnsubscribes" => 2,
-    					"UnsubscribesToday" => 0,
-    					"UnsubscribesYesterday" => 2,
-    					"UnsubscribesThisWeek" => 2,
-    					"UnsubscribesThisMonth" => 2,
-    					"UnsubscribesThisYear" => 2,
-    					"TotalDeleted" => 0,
-    					"DeletedToday" => 0,
-    					"DeletedYesterday" => 0,
-    					"DeletedThisWeek" => 0,
-    					"DeletedThisMonth" => 0,
-    					"DeletedThisYear" => 0,
-    					"TotalBounces" => 0,
-    					"BouncesToday" => 0,
-    					"BouncesYesterday" => 0,
-    					"BouncesThisWeek" => 0,
-    					"BouncesThisMonth" => 0,
-    					"BouncesThisYear" => 0
-    			),
-    			'bounced_subscribers' => array(
-    					'Results' => array(
-    							array(
-    									'EmailAddress' => 'bouncedsubscriber@example.com',
-    									'Name' => 'Bounced One',
-    									'Date' => '2010-10-25 13:11:00',
-    									'State' => 'Bounced',
-    									'CustomFields' => array()
-    							)
-    					),
-    					'ResultsOrderedBy' => 'email',
-    					'OrderDirection' => 'asc',
-    					'PageNumber' => 1,
-    					'PageSize' => 1000,
-    					'RecordsOnThisPage' => 1,
-    					'TotalNumberOfRecords' => 1,
-    					'NumberOfPages' => 1
-    			),
-    			'unsubscribed_subscribers' => array(
-    					"Results" => array(
-    							array(
-    									"EmailAddress" => "subscriber@example.com",
-    									"Name" => "Unsub One",
-    									"Date" => "2010-10-25 13:11:00",
-    									"State" => "Unsubscribed",
-    									"CustomFields" => array()
-    							),
-    							array(
-    									"EmailAddress" => "subscriberone@example.com",
-    									"Name" => "Subscriber",
-    									"Date" => "2010-10-25 13:04:00",
-    									"State" => "Unsubscribed",
-    									"CustomFields" => array(
-    											array(
-    													"Key" => "website",
-    													"Value" => "http://google.com"
-    											)
-    									)
-    							),
-    							array(
-    									"EmailAddress" => "example+1@example.com",
-    									"Name" => "Example One",
-    									"Date" => "2010-10-26 10:56:00",
-    									"State" => "Unsubscribed",
-    									"CustomFields" => array()
-    							),
-    							array(
-    									"EmailAddress" => "example+2@example.com",
-    									"Name" => "Example Two",
-    									"Date" => "2010-10-26 10:56:00",
-    									"State" => "Unsubscribed",
-    									"CustomFields" => array()
-    							),
-    							array(
-    									"EmailAddress" => "example+3@example.com",
-    									"Name" => "Example Three",
-    									"Date" => "2010-10-26 10:56:00",
-    									"State" => "Unsubscribed",
-    									"CustomFields" => array()
-    							)
-    					),
-    					"ResultsOrderedBy" => "email",
-    					"OrderDirection" => "asc",
-    					"PageNumber" => 1,
-    					"PageSize" => 1000,
-    					"RecordsOnThisPage" => 5,
-    					"TotalNumberOfRecords" => 5,
-    					"NumberOfPages" => 1
-    			),
-    			'list_webhooks' => array(
-    					array(
-    							"WebhookID" => "943678317049bc13",
-    							"Events" => array(
-    									"Bounce",
-    									"Spam"
-    							),
-    							"Url" => "http://www.postbin.org/d9w8ud9wud9w",
-    							"Status" => "Active",
-    							"PayloadFormat" => "Json"
-    					),
-    					array(
-    							"WebhookID" => "ee1b3864e5ca6161",
-    							"Events" => array(
-    									"Subscribe"
-    							),
-    							"Url" => "http://www.postbin.org/hiuhiu2h2u",
-    							"Status" => "Active",
-    							"PayloadFormat" => "Xml"
-    					)
-    			),
-    			'create_list_webhook' => '6a783d359bd44ef62c6ca0d3eda4412a'
-    	);
+        $campaign_responses = array(
+            'create_campaign' => '787y87y87y87y87y87y87',
+            'campaign_unsubscribes' => array(
+                'Results' => array(
+                    array(
+                        'EmailAddress' => 'subs+6576576576@example.com',
+                        'ListID' => '512a3bc577a58fdf689c654329b50fa0',
+                        'Date' => '2010-10-11 08:29:00',
+                        'IPAddress' => '192.168.126.87'
+                    )
+                ),
+                'ResultsOrderedBy' => 'date',
+                'OrderDirection' => 'asc',
+                'PageNumber' => 1,
+                'PageSize' => 1000,
+                'RecordsOnThisPage' => 1,
+                'TotalNumberOfRecords' => 1,
+                'NumberOfPages' => 1
+            ),
+            'campaign_summary' => array(
+                'Name' => 'Campaign One',
+                'Recipients' => 5,
+                'TotalOpened' => 10,
+                'Clicks' => 0,
+                'Unsubscribed' => 0,
+                'Bounced' => 0,
+                'UniqueOpened' => 5,
+                'WebVersionURL' => 'http://clientone.createsend.com/t/ViewEmail/r/3A433FC72FFE3B8B/C67FD2F38AC4859C/',
+                'WebVersionTextURL' => 'http://createsend.com/t/r-3A433FC72FFE3B8B/t',
+                'WorldviewURL' => 'http://clientone.createsend.com/reports/wv/r/3A433FC72FFE3B8B',
+                'ForwardToAFriends' => 18,
+                'FacebookLikes' => 25,
+                'TwitterTweets' => 11
+            ),
+            'campaign_listsandsegments' => array(
+                'Lists' => array(
+                    array(
+                        'ListID' => 'a58ee1d3039b8bec838e6d1482a8a965',
+                        'Name' => 'List One'
+                    )
+                ),
+                'Segments' => array(
+                    array(
+                        'ListID' => '2bea949d0bf96148c3e6a209d2e82060',
+                        'SegmentID' => 'dba84a225d5ce3d19105d7257baac46f',
+                        'Title' => 'Segment for campaign'
+                    )
+                )
+            ),
+            'campaign_opens' => array(
+                "Results" => array(
+                    array(
+                        "EmailAddress" => "subs+6576576576@example.com",
+                        "ListID" => "512a3bc577a58fdf689c654329b50fa0",
+                        "Date" => "2010-10-11 08:29:00",
+                        "IPAddress" => "192.168.126.87",
+                        "Latitude" => -33.8683,
+                        "Longitude" => 151.2086,
+                        "City" => "Sydney",
+                        "Region" => "New South Wales",
+                        "CountryCode" => "AU",
+                        "CountryName" => "Australia"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6576576576@example.com",
+                        "ListID" => "512a3bc577a58fdf689c654329b50fa0",
+                        "Date" => "2010-10-08 14:24:00",
+                        "IPAddress" => "192.168.126.87",
+                        "Latitude" => -33.8683,
+                        "Longitude" => 151.2086,
+                        "City" => "Sydney",
+                        "Region" => "New South Wales",
+                        "CountryCode" => "AU",
+                        "CountryName" => "Australia"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6576576576@example.com",
+                        "ListID" => "512a3bc577a58fdf689c654329b50fa0",
+                        "Date" => "2010-10-07 10:20:00",
+                        "IPAddress" => "192.168.126.87",
+                        "Latitude" => -33.8683,
+                        "Longitude" => 151.2086,
+                        "City" => "Sydney",
+                        "Region" => "New South Wales",
+                        "CountryCode" => "AU",
+                        "CountryName" => "Australia"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6576576576@example.com",
+                        "ListID" => "512a3bc577a58fdf689c654329b50fa0",
+                        "Date" => "2010-10-07 07:15:00",
+                        "IPAddress" => "192.168.126.87",
+                        "Latitude" => -33.8683,
+                        "Longitude" => 151.2086,
+                        "City" => "Sydney",
+                        "Region" => "New South Wales",
+                        "CountryCode" => "AU",
+                        "CountryName" => "Australia"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6576576576@example.com",
+                        "ListID" => "512a3bc577a58fdf689c654329b50fa0",
+                        "Date" => "2010-10-07 06:58:00",
+                        "IPAddress" => "192.168.126.87",
+                        "Latitude" => -33.8683,
+                        "Longitude" => 151.2086,
+                        "City" => "Sydney",
+                        "Region" => "New South Wales",
+                        "CountryCode" => "AU",
+                        "CountryName" => "Australia"
+                    )
+                ),
+                "ResultsOrderedBy" => "date",
+                "OrderDirection" => "asc",
+                "PageNumber" => 1,
+                "PageSize" => 1000,
+                "RecordsOnThisPage" => 5,
+                "TotalNumberOfRecords" => 5,
+                "NumberOfPages" => 1
+            ),
+            'campaign_recipients' => array(
+                'Results' => array(
+                    array(
+                        "EmailAddress" => "subs+6g76t7t0@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t10@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t100@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1000@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1001@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1002@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1003@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1004@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1005@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1006@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1007@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1008@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1009@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t101@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1010@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1011@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1012@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1013@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6g76t7t1014@example.com",
+                        "ListID" => "a994a3caf1328a16af9a69a730eaa706"
+                    )
+                ),
+                'ResultsOrderedBy' => 'email',
+                'OrderDirection' => 'asc',
+                'PageNumber' => 1,
+                'PageSize' => 20,
+                'RecordsOnThisPage' => 20,
+                'TotalNumberOfRecords' => 2200,
+                'NumberOfPages' => 110
+            ),
+            'campaign_clicks' => array(
+                "Results" => array(
+                    array(
+                        "EmailAddress" => "subs+6576576576@example.com",
+                        "URL" => "http://video.google.com.au/?hl=en&tab=wv",
+                        "ListID" => "512a3bc577a58fdf689c654329b50fa0",
+                        "Date" => "2010-10-11 08:29:00",
+                        "IPAddress" => "192.168.126.87",
+                        "Latitude" => -33.8683,
+                        "Longitude" => 151.2086,
+                        "City" => "Sydney",
+                        "Region" => "New South Wales",
+                        "CountryCode" => "AU",
+                        "CountryName" => "Australia"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6576576576@example.com",
+                        "URL" => "http://mail.google.com/mail/?hl=en&tab=wm",
+                        "ListID" => "512a3bc577a58fdf689c654329b50fa0",
+                        "Date" => "2010-10-11 08:29:00",
+                        "IPAddress" => "192.168.126.87",
+                        "Latitude" => -33.8683,
+                        "Longitude" => 151.2086,
+                        "City" => "Sydney",
+                        "Region" => "New South Wales",
+                        "CountryCode" => "AU",
+                        "CountryName" => "Australia"
+                    ),
+                    array(
+                        "EmailAddress" => "subs+6576576576@example.com",
+                        "URL" => "http://mail.google.com/mail/?hl=en&tab=wm",
+                        "ListID" => "512a3bc577a58fdf689c654329b50fa0",
+                        "Date" => "2010-10-06 17:24:00",
+                        "IPAddress" => "192.168.126.87",
+                        "Latitude" => -33.8683,
+                        "Longitude" => 151.2086,
+                        "City" => "Sydney",
+                        "Region" => "New South Wales",
+                        "CountryCode" => "AU",
+                        "CountryName" => "Australia"
+                    )
+                ),
+                "ResultsOrderedBy" => "date",
+                "OrderDirection" => "asc",
+                "PageNumber" => 1,
+                "PageSize" => 1000,
+                "RecordsOnThisPage" => 3,
+                "TotalNumberOfRecords" => 3,
+                "NumberOfPages" => 1
+            ),
+            'campaign_bounces' => array(
+                "Results" => array(
+                    array(
+                        "EmailAddress" => "asdf@softbouncemyemail.com",
+                        "ListID" => "654523a5855b4a440bae3fb295641546",
+                        "BounceType" => "Soft",
+                        "Date" => "2010-07-02 16:46:00",
+                        "Reason" => "Bounce - But No Email Address Returned "
+                    ),
+                    array(
+                        "EmailAddress" => "asdf@hardbouncemyemail.com",
+                        "ListID" => "654523a5855b4a440bae3fb295641546",
+                        "BounceType" => "Soft",
+                        "Date" => "2010-07-02 16:46:00",
+                        "Reason" => "Soft Bounce - General"
+                    )
+                ),
+                "ResultsOrderedBy" => "date",
+                "OrderDirection" => "asc",
+                "PageNumber" => 1,
+                "PageSize" => 1000,
+                "RecordsOnThisPage" => 2,
+                "TotalNumberOfRecords" => 2,
+                "NumberOfPages" => 1
+            )
+        );
 
-    	$campaign_responses = array(
-    			'create_campaign' => '787y87y87y87y87y87y87',
-    			'campaign_unsubscribes' => array(
-    					'Results' => array(
-    							array(
-    									'EmailAddress' => 'subs+6576576576@example.com',
-    									'ListID' => '512a3bc577a58fdf689c654329b50fa0',
-    									'Date' => '2010-10-11 08:29:00',
-    									'IPAddress' => '192.168.126.87'
-    							)
-    					),
-    					'ResultsOrderedBy' => 'date',
-    					'OrderDirection' => 'asc',
-    					'PageNumber' => 1,
-    					'PageSize' => 1000,
-    					'RecordsOnThisPage' => 1,
-    					'TotalNumberOfRecords' => 1,
-    					'NumberOfPages' => 1
-    			),
-    			'campaign_summary' => array(
-                        'Name' => 'Campaign One',
-    					'Recipients' => 5,
-    					'TotalOpened' => 10,
-    					'Clicks' => 0,
-    					'Unsubscribed' => 0,
-    					'Bounced' => 0,
-    					'UniqueOpened' => 5,
-    					'WebVersionURL' => 'http://clientone.createsend.com/t/ViewEmail/r/3A433FC72FFE3B8B/C67FD2F38AC4859C/',
-    					'WebVersionTextURL' => 'http://createsend.com/t/r-3A433FC72FFE3B8B/t',
-    					'WorldviewURL' => 'http://clientone.createsend.com/reports/wv/r/3A433FC72FFE3B8B',
-    					'ForwardToAFriends' => 18,
-    					'FacebookLikes' => 25,
-    					'TwitterTweets' => 11
-    			),
-    			'campaign_listsandsegments' => array(
-    					'Lists' => array(
-    							array(
-    									'ListID' => 'a58ee1d3039b8bec838e6d1482a8a965',
-    									'Name' => 'List One'
-    							)
-    					),
-    					'Segments' => array(
-    							array(
-    									'ListID' => '2bea949d0bf96148c3e6a209d2e82060',
-    									'SegmentID' => 'dba84a225d5ce3d19105d7257baac46f',
-    									'Title' => 'Segment for campaign'
-    							)
-    					)
-    			),
-    			'campaign_opens' => array(
-    					"Results" => array(
-    							array(
-    									"EmailAddress" => "subs+6576576576@example.com",
-    									"ListID" => "512a3bc577a58fdf689c654329b50fa0",
-    									"Date" => "2010-10-11 08:29:00",
-    									"IPAddress" => "192.168.126.87",
-                      "Latitude" => -33.8683,
-                      "Longitude" => 151.2086,
-                      "City" => "Sydney",
-                      "Region" => "New South Wales",
-                      "CountryCode" => "AU",
-                      "CountryName" => "Australia"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6576576576@example.com",
-    									"ListID" => "512a3bc577a58fdf689c654329b50fa0",
-    									"Date" => "2010-10-08 14:24:00",
-    									"IPAddress" => "192.168.126.87",
-                      "Latitude" => -33.8683,
-                      "Longitude" => 151.2086,
-                      "City" => "Sydney",
-                      "Region" => "New South Wales",
-                      "CountryCode" => "AU",
-                      "CountryName" => "Australia"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6576576576@example.com",
-    									"ListID" => "512a3bc577a58fdf689c654329b50fa0",
-    									"Date" => "2010-10-07 10:20:00",
-    									"IPAddress" => "192.168.126.87",
-                      "Latitude" => -33.8683,
-                      "Longitude" => 151.2086,
-                      "City" => "Sydney",
-                      "Region" => "New South Wales",
-                      "CountryCode" => "AU",
-                      "CountryName" => "Australia"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6576576576@example.com",
-    									"ListID" => "512a3bc577a58fdf689c654329b50fa0",
-    									"Date" => "2010-10-07 07:15:00",
-    									"IPAddress" => "192.168.126.87",
-                      "Latitude" => -33.8683,
-                      "Longitude" => 151.2086,
-                      "City" => "Sydney",
-                      "Region" => "New South Wales",
-                      "CountryCode" => "AU",
-                      "CountryName" => "Australia"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6576576576@example.com",
-    									"ListID" => "512a3bc577a58fdf689c654329b50fa0",
-    									"Date" => "2010-10-07 06:58:00",
-    									"IPAddress" => "192.168.126.87",
-                      "Latitude" => -33.8683,
-                      "Longitude" => 151.2086,
-                      "City" => "Sydney",
-                      "Region" => "New South Wales",
-                      "CountryCode" => "AU",
-                      "CountryName" => "Australia"
-    							)
-    					),
-    					"ResultsOrderedBy" => "date",
-    					"OrderDirection" => "asc",
-    					"PageNumber" => 1,
-    					"PageSize" => 1000,
-    					"RecordsOnThisPage" => 5,
-    					"TotalNumberOfRecords" => 5,
-    					"NumberOfPages" => 1
-    			),
-    			'campaign_recipients' => array(
-    					'Results' => array(
-    							array(
-    									"EmailAddress" => "subs+6g76t7t0@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t10@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t100@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1000@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1001@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1002@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1003@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1004@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1005@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1006@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1007@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1008@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1009@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t101@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1010@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1011@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1012@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1013@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6g76t7t1014@example.com",
-    									"ListID" => "a994a3caf1328a16af9a69a730eaa706"
-    							)
-    					),
-    					'ResultsOrderedBy' => 'email',
-    					'OrderDirection' => 'asc',
-    					'PageNumber' => 1,
-    					'PageSize' => 20,
-    					'RecordsOnThisPage' => 20,
-    					'TotalNumberOfRecords' => 2200,
-    					'NumberOfPages' => 110
-    			),
-    			'campaign_clicks' => array(
-    					"Results" => array(
-    							array(
-    									"EmailAddress" => "subs+6576576576@example.com",
-    									"URL" => "http://video.google.com.au/?hl=en&tab=wv",
-    									"ListID" => "512a3bc577a58fdf689c654329b50fa0",
-    									"Date" => "2010-10-11 08:29:00",
-    									"IPAddress" => "192.168.126.87",
-                      "Latitude" => -33.8683,
-                      "Longitude" => 151.2086,
-                      "City" => "Sydney",
-                      "Region" => "New South Wales",
-                      "CountryCode" => "AU",
-                      "CountryName" => "Australia"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6576576576@example.com",
-    									"URL" => "http://mail.google.com/mail/?hl=en&tab=wm",
-    									"ListID" => "512a3bc577a58fdf689c654329b50fa0",
-    									"Date" => "2010-10-11 08:29:00",
-    									"IPAddress" => "192.168.126.87",
-                      "Latitude" => -33.8683,
-                      "Longitude" => 151.2086,
-                      "City" => "Sydney",
-                      "Region" => "New South Wales",
-                      "CountryCode" => "AU",
-                      "CountryName" => "Australia"
-    							),
-    							array(
-    									"EmailAddress" => "subs+6576576576@example.com",
-    									"URL" => "http://mail.google.com/mail/?hl=en&tab=wm",
-    									"ListID" => "512a3bc577a58fdf689c654329b50fa0",
-    									"Date" => "2010-10-06 17:24:00",
-    									"IPAddress" => "192.168.126.87",
-                      "Latitude" => -33.8683,
-                      "Longitude" => 151.2086,
-                      "City" => "Sydney",
-                      "Region" => "New South Wales",
-                      "CountryCode" => "AU",
-                      "CountryName" => "Australia"
-    							)
-    					),
-    					"ResultsOrderedBy" => "date",
-    					"OrderDirection" => "asc",
-    					"PageNumber" => 1,
-    					"PageSize" => 1000,
-    					"RecordsOnThisPage" => 3,
-    					"TotalNumberOfRecords" => 3,
-    					"NumberOfPages" => 1
-    			),
-    			'campaign_bounces' => array(
-    					"Results" => array(
-    							array(
-    									"EmailAddress" => "asdf@softbouncemyemail.com",
-    									"ListID" => "654523a5855b4a440bae3fb295641546",
-    									"BounceType" => "Soft",
-    									"Date" => "2010-07-02 16:46:00",
-    									"Reason" => "Bounce - But No Email Address Returned "
-    							),
-    							array(
-    									"EmailAddress" => "asdf@hardbouncemyemail.com",
-    									"ListID" => "654523a5855b4a440bae3fb295641546",
-    									"BounceType" => "Soft",
-    									"Date" => "2010-07-02 16:46:00",
-    									"Reason" => "Soft Bounce - General"
-    							)
-    					),
-    					"ResultsOrderedBy" => "date",
-    					"OrderDirection" => "asc",
-    					"PageNumber" => 1,
-    					"PageSize" => 1000,
-    					"RecordsOnThisPage" => 2,
-    					"TotalNumberOfRecords" => 2,
-    					"NumberOfPages" => 1
-    			)
-    	);
+        $segment_responses = array(
+            'segment_subscribers' => array(
+                "Results" => array(
+                    array(
+                        "EmailAddress" => "personone@example.com",
+                        "Name" => "Person One",
+                        "Date" => "2010-10-27 13:13:00",
+                        "State" => "Active",
+                        "CustomFields" => array()
+                    ),
+                    array(
+                        "EmailAddress" => "persontwo@example.com",
+                        "Name" => "Person Two",
+                        "Date" => "2010-10-27 13:13:00",
+                        "State" => "Active",
+                        "CustomFields" => array()
+                    )
+                ),
+                "ResultsOrderedBy" => "email",
+                "OrderDirection" => "asc",
+                "PageNumber" => 1,
+                "PageSize" => 1000,
+                "RecordsOnThisPage" => 2,
+                "TotalNumberOfRecords" => 2,
+                "NumberOfPages" => 1
+            ),
+            'create_segment' => '0246c2aea610a3545d9780bf6ab89006'
+        );
 
-    	$segment_responses = array(
-    			'segment_subscribers' => array(
-    					"Results" => array(
-    							array(
-    									"EmailAddress" => "personone@example.com",
-    									"Name" => "Person One",
-    									"Date" => "2010-10-27 13:13:00",
-    									"State" => "Active",
-    									"CustomFields" => array()
-    							),
-    							array(
-    									"EmailAddress" => "persontwo@example.com",
-    									"Name" => "Person Two",
-    									"Date" => "2010-10-27 13:13:00",
-    									"State" => "Active",
-    									"CustomFields" => array()
-    							)
-    					),
-    					"ResultsOrderedBy" => "email",
-    					"OrderDirection" => "asc",
-    					"PageNumber" => 1,
-    					"PageSize" => 1000,
-    					"RecordsOnThisPage" => 2,
-    					"TotalNumberOfRecords" => 2,
-    					"NumberOfPages" => 1
-    			),
-    			'create_segment' => '0246c2aea610a3545d9780bf6ab89006'
-    	);
+        $template_responses = array(
+            'create_template' => '98y2e98y289dh89h938389',
+            'template_details' => array(
+                'TemplateID' => '98y2e98y289dh89h938389',
+                'Name' => 'Template One',
+                'PreviewURL' => 'http://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=01AF532CD8889B33&d=r&c=E816F55BFAD1A753',
+                'ScreenshotURL' => 'http://preview.createsend.com/ts/r/14/833/263/14833263.jpg?0318092600'
+            ),
+            'templates' => array(
+                array(
+                    "TemplateID" => "5cac213cf061dd4e008de5a82b7a3621",
+                    "Name" => "Template One",
+                    "PreviewURL" => "http://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=01AF532CD8889B33&d=r&c=E816F55BFAD1A753",
+                    "ScreenshotURL" => "http://preview.createsend.com/ts/r/14/833/263/14833263.jpg?0318092541"
+                ),
+                array(
+                    "TemplateID" => "da645c271bc85fb6550acff937c2ab2e",
+                    "Name" => "Template Two",
+                    "PreviewURL" => "http://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=C8A180629495E798&d=r&c=E816F55BFAD1A753",
+                    "ScreenshotURL" => "http://preview.createsend.com/ts/r/18/7B3/552/187B3552.jpg?0705043527"
+                )
+            )
+        );
 
-    	$template_responses = array(
-    			'create_template' => '98y2e98y289dh89h938389',
-    			'template_details' => array(
-    					'TemplateID' => '98y2e98y289dh89h938389',
-    					'Name' => 'Template One',
-    					'PreviewURL' => 'http://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=01AF532CD8889B33&d=r&c=E816F55BFAD1A753',
-    					'ScreenshotURL' => 'http://preview.createsend.com/ts/r/14/833/263/14833263.jpg?0318092600'
-    			),
-    			'templates' => array(
-    					array(
-    							"TemplateID" => "5cac213cf061dd4e008de5a82b7a3621",
-    							"Name" => "Template One",
-    							"PreviewURL" => "http://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=01AF532CD8889B33&d=r&c=E816F55BFAD1A753",
-    							"ScreenshotURL" => "http://preview.createsend.com/ts/r/14/833/263/14833263.jpg?0318092541"
-    					),
-    					array(
-    							"TemplateID" => "da645c271bc85fb6550acff937c2ab2e",
-    							"Name" => "Template Two",
-    							"PreviewURL" => "http://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=C8A180629495E798&d=r&c=E816F55BFAD1A753",
-    							"ScreenshotURL" => "http://preview.createsend.com/ts/r/18/7B3/552/187B3552.jpg?0705043527"
-    					)
-    			)
-    	);
-
-    	$this->responses = array_merge(
-    			array_merge(
-    					array_merge(
-    							array_merge(
-    									array_merge(
-    											array_merge(
-    													$util_responses,
-    													$client_responses
-    											),
-    											$subscriber_responses
-    									),
-    									$list_responses
-    							),
-    							$campaign_responses
-    					),
-    					$segment_responses
-    			),
-    			$template_responses
-    	);
+        $this->responses = array_merge(
+            array_merge(
+                array_merge(
+                    array_merge(
+                        array_merge(
+                            array_merge(
+                                $util_responses,
+                                $client_responses
+                            ),
+                            $subscriber_responses
+                        ),
+                        $list_responses
+                    ),
+                    $campaign_responses
+                ),
+                $segment_responses
+            ),
+            $template_responses
+        );
     }
 
     

--- a/tests/class_tests/response_tests.php
+++ b/tests/class_tests/response_tests.php
@@ -105,7 +105,8 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                         'FromEmail' => 'myemail@example.com',
                         'ReplyTo' => 'myemail@example.com',
                         'SentDate' => '2010-10-06 16:20:00',
-                        'TotalRecipients' => 11222
+                        'TotalRecipients' => 11222,
+                        'Tags' => array()
                     )
                 ),
                 'ResultsOrderedBy' => 'SentDate',

--- a/tests/class_tests/response_tests.php
+++ b/tests/class_tests/response_tests.php
@@ -77,32 +77,45 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
     					)
     			),
     			'create_client' => '32a381c49a2df99f1d0c6f3c112352b9',
-    			'campaigns' => array(
-    					array(
-    							'WebVersionURL' => 'http://hello.createsend.com/t/ViewEmail/r/765E86829575EE2C/C67FD2F38AC4859C/',
-  							  'WebVersionTextURL' => 'http://createsend.com/t/r-765E86829575EE2C/t',
-    							'CampaignID' => 'fc0ce7105baeaf97f47c99be31d02a91',
-    							'Subject' => 'Campaign One',
-    							'Name' => 'Campaign One',
-                  'FromName' => 'My Name',
-                  'FromEmail' => 'myemail@example.com',
-                  'ReplyTo' => 'myemail@example.com',
-    							'SentDate' => '2010-10-12 12:58:00',
-    							'TotalRecipients' => 2245
-    					),
-    					array(
-    							'WebVersionURL' => 'http://hello.createsend.com/t/ViewEmail/r/DD543566A87C9B8B/C67FD2F38AC4859C/',
-    							'WebVersionTextURL' => 'http://createsend.com/t/r-DD543566A87C9B8B/t',
-    							'CampaignID' => '072472b88c853ae5dedaeaf549a8d607',
-    							'Subject' => 'Campaign Two',
-    							'Name' => 'Campaign Two',
-                  'FromName' => 'My Name',
-                  'FromEmail' => 'myemail@example.com',
-                  'ReplyTo' => 'myemail@example.com',
-    							'SentDate' => '2010-10-06 16:20:00',
-    							'TotalRecipients' => 11222
-    					)
-    			),
+
+                'campaigns' => array(
+                    'Results' => array(
+                        array(
+                            'WebVersionURL' => 'http://hello.createsend.com/t/ViewEmail/r/765E86829575EE2C/C67FD2F38AC4859C/',
+                            'WebVersionTextURL' => 'http://createsend.com/t/r-765E86829575EE2C/t',
+                            'CampaignID' => 'fc0ce7105baeaf97f47c99be31d02a91',
+                            'Subject' => 'Campaign One',
+                            'Name' => 'Campaign One',
+                            'FromName' => 'My Name',
+                            'FromEmail' => 'myemail@example.com',
+                            'ReplyTo' => 'myemail@example.com',
+                            'SentDate' => '2010-10-12 12:58:00',
+                            'TotalRecipients' => 2245,
+                            'Tags' => array(
+                                'Tag1', 'Tag2'
+                            )
+                        ),
+                        array(
+                            'WebVersionURL' => 'http://hello.createsend.com/t/ViewEmail/r/DD543566A87C9B8B/C67FD2F38AC4859C/',
+                            'WebVersionTextURL' => 'http://createsend.com/t/r-DD543566A87C9B8B/t',
+                            'CampaignID' => '072472b88c853ae5dedaeaf549a8d607',
+                            'Subject' => 'Campaign Two',
+                            'Name' => 'Campaign Two',
+                            'FromName' => 'My Name',
+                            'FromEmail' => 'myemail@example.com',
+                            'ReplyTo' => 'myemail@example.com',
+                            'SentDate' => '2010-10-06 16:20:00',
+                            'TotalRecipients' => 11222
+                        )
+                    ),
+                    'ResultsOrderedBy' => 'SentDate',
+                    'OrderDirection' => "desc",
+                    'PageNumber' => 1,
+                    'PageSize' => 2,
+                    'RecordsOnThisPage' => 2,
+                    'TotalNumberOfRecords' => 49,
+                    'NumberOfPages' => 25
+                ),
     			'scheduled' => array(
     					array(
     							"DateScheduled" => "2011-05-25 10:40:00",
@@ -115,7 +128,8 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                   'ReplyTo' => 'myemail@example.com',
     							"DateCreated" => "2011-05-24 10:37:00",
     							"PreviewURL" => "http://createsend.com/t/r-DD543521A87C9B8B",
-  							  "PreviewTextURL" => "http://createsend.com/t/r-DD543521A87C9B8B/t"
+  							  "PreviewTextURL" => "http://createsend.com/t/r-DD543521A87C9B8B/t",
+                            "Tags" => array("Tag1", "Tag2")
     					),
     					array(
     							"DateScheduled" => "2011-05-29 11:20:00",
@@ -128,7 +142,8 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                   'ReplyTo' => 'myemail@example.com',
     							"DateCreated" => "2011-05-24 10:39:00",
     							"PreviewURL" => "http://createsend.com/t/r-DD913521A87C9B8B",
-    							"PreviewTextURL" => "http://createsend.com/t/r-DD913521A87C9B8B/t"
+    							"PreviewTextURL" => "http://createsend.com/t/r-DD913521A87C9B8B/t",
+                            "Tags" => array()
     					)
     			),
     			'drafts' => array(
@@ -141,7 +156,8 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                   'ReplyTo' => 'myemail@example.com',
     							"DateCreated" => "2010-08-19 16:08:00",
     							"PreviewURL" => "http://hello.createsend.com/t/ViewEmail/r/E97A7BB2E6983DA1/C67FD2F38AC4859C/",
-    							"PreviewTextURL" => "http://createsend.com/t/r-E97A7BB2E6983DA1/t"
+    							"PreviewTextURL" => "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
+                            "Tags" => array()
     					),
     					array(
     							"CampaignID" => "2e928e982065d92627139208c8c01db1",
@@ -152,7 +168,8 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                   'ReplyTo' => 'myemail@example.com',
     							"DateCreated" => "2010-08-19 16:08:00",
     							"PreviewURL" => "http://hello.createsend.com/t/ViewEmail/r/E97A7BB2E6983DA1/C67FD2F38AC4859C/",
-    							"PreviewTextURL" => "http://createsend.com/t/r-E97A7BB2E6983DA1/t"
+    							"PreviewTextURL" => "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
+                            "Tags" => array("Tag1", "Tag2")
     					)
     			),
     			'lists' => array(
@@ -217,7 +234,17 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
     					"RecordsOnThisPage" => 5,
     					"TotalNumberOfRecords" => 5,
     					"NumberOfPages" => 1
-    			)
+    			),
+                'tags' => array(
+                    array(
+                        'Name' => 'Tag One',
+                        'NumberOfCampaigns' => 120,
+                    ),
+                    array(
+                        'Name' => 'Tag Two',
+                        'NumberOfCampaigns' => 62,
+                    )
+                )
     	);
 
     	$subscriber_responses = array(
@@ -551,6 +578,7 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
     					'NumberOfPages' => 1
     			),
     			'campaign_summary' => array(
+                        'Name' => 'Campaign One',
     					'Recipients' => 5,
     					'TotalOpened' => 10,
     					'Clicks' => 0,

--- a/tests/csrest_clients_test.php
+++ b/tests/csrest_clients_test.php
@@ -161,6 +161,14 @@ abstract class CS_REST_TestClients extends CS_REST_TestBase {
         $this->general_test('get_templates', $call_options, $raw_result, $deserialised);
     }
 
+    function testget_tags() {
+        $raw_result = 'some tags';
+        $deserialised = array('Tag One', 'Tag Two');
+        $call_options = $this->get_call_options($this->client_base_route.'tags.json');
+
+        $this->general_test('get_tags', $call_options, $raw_result, $deserialised);
+    }
+
     function testget() {
         $raw_result = 'client data';
         $deserialised = array('CompanyName' => 'Widget Land');

--- a/tests/csrest_test.php
+++ b/tests/csrest_test.php
@@ -31,7 +31,7 @@ class CS_REST_TestBase extends UnitTestCase {
         $this->mock_transport->setReturnValue('get_type', $this->transport_type);
         $this->mock_serialiser->setReturnValue('get_type', $this->serialisation_type);
 
-        $this->base_route = $this->protocol.'://'.$this->api_host.'/api/v3.2/';
+        $this->base_route = $this->protocol.'://'.$this->api_host.'/api/v3.3/';
 
         $this->set_up_inner();
     }

--- a/tests/responses/active_subscribers.json
+++ b/tests/responses/active_subscribers.json
@@ -4,6 +4,7 @@
       "EmailAddress": "subs+7t8787Y@example.com",
       "Name": "Person One",
       "Date": "2010-10-25 10:28:00",
+      "ListJoinedDate": "2010-10-25 10:28:00",
       "State": "Active",
       "CustomFields": [
         {
@@ -25,6 +26,7 @@
       "EmailAddress": "subs+7878787y8ggg@example.com",
       "Name": "Person Two",
       "Date": "2010-10-25 12:17:00",
+      "ListJoinedDate": "2010-10-25 12:17:00",
       "State": "Active",
       "CustomFields": [
         {
@@ -38,6 +40,7 @@
       "EmailAddress": "subs+7890909i0ggg@example.com",
       "Name": "Person Three",
       "Date": "2010-10-25 12:52:00",
+      "ListJoinedDate": "2010-10-25 12:52:00",
       "State": "Active",
       "CustomFields": [
         {
@@ -51,6 +54,7 @@
       "EmailAddress": "subs@example.com",
       "Name": "Person Four",
       "Date": "2010-10-27 13:13:00",
+      "ListJoinedDate": "2010-10-27 13:13:00",
       "State": "Active",
       "CustomFields": [],
       "ReadsEmailWith": ""
@@ -59,6 +63,7 @@
       "EmailAddress": "joey@example.com",
       "Name": "Person Five",
       "Date": "2010-10-27 13:13:00",
+      "ListJoinedDate": "2010-10-27 13:13:00",
       "State": "Active",
       "CustomFields": [],
       "ReadsEmailWith": "Gmail"

--- a/tests/responses/bounced_subscribers.json
+++ b/tests/responses/bounced_subscribers.json
@@ -4,6 +4,7 @@
       "EmailAddress": "bouncedsubscriber@example.com",
       "Name": "Bounced One",
       "Date": "2010-10-25 13:11:00",
+      "ListJoinedDate": "2010-10-25 13:11:00",
       "State": "Bounced",
       "CustomFields": [],
       "ReadsEmailWith": ""

--- a/tests/responses/campaign_summary.json
+++ b/tests/responses/campaign_summary.json
@@ -1,4 +1,5 @@
 {
+  "Name": "Campaign One",
   "Recipients": 5,
   "TotalOpened": 10,
   "Clicks": 0,

--- a/tests/responses/campaigns.json
+++ b/tests/responses/campaigns.json
@@ -1,26 +1,36 @@
-[
-  {
-    "WebVersionURL": "http://hello.createsend.com/t/ViewEmail/r/765E86829575EE2C/C67FD2F38AC4859C/",
-    "WebVersionTextURL": "http://createsend.com/t/r-765E86829575EE2C/t",
-    "CampaignID": "fc0ce7105baeaf97f47c99be31d02a91",
-    "Subject": "Campaign One",
-    "Name": "Campaign One",
-    "FromName": "My Name",
-    "FromEmail": "myemail@example.com",
-    "ReplyTo": "myemail@example.com",
-    "SentDate": "2010-10-12 12:58:00",
-    "TotalRecipients": 2245
-  },
-  {
-    "WebVersionURL": "http://hello.createsend.com/t/ViewEmail/r/DD543566A87C9B8B/C67FD2F38AC4859C/",
-    "WebVersionTextURL": "http://createsend.com/t/r-DD543566A87C9B8B/t",
-    "CampaignID": "072472b88c853ae5dedaeaf549a8d607",
-    "Subject": "Campaign Two",
-    "Name": "Campaign Two",
-    "FromName": "My Name",
-    "FromEmail": "myemail@example.com",
-    "ReplyTo": "myemail@example.com",
-    "SentDate": "2010-10-06 16:20:00",
-    "TotalRecipients": 11222
-  }
-]
+{
+  "Results": [
+    {
+      "WebVersionURL": "http://hello.createsend.com/t/ViewEmail/r/765E86829575EE2C/C67FD2F38AC4859C/",
+      "WebVersionTextURL": "http://createsend.com/t/r-765E86829575EE2C/t",
+      "CampaignID": "fc0ce7105baeaf97f47c99be31d02a91",
+      "Subject": "Campaign One",
+      "Name": "Campaign One",
+      "FromName": "My Name",
+      "FromEmail": "myemail@example.com",
+      "ReplyTo": "myemail@example.com",
+      "SentDate": "2010-10-12 12:58:00",
+      "TotalRecipients": 2245,
+      "Tags": ["Tag1", "Tag2"]
+    },
+    {
+      "WebVersionURL": "http://hello.createsend.com/t/ViewEmail/r/DD543566A87C9B8B/C67FD2F38AC4859C/",
+      "WebVersionTextURL": "http://createsend.com/t/r-DD543566A87C9B8B/t",
+      "CampaignID": "072472b88c853ae5dedaeaf549a8d607",
+      "Subject": "Campaign Two",
+      "Name": "Campaign Two",
+      "FromName": "My Name",
+      "FromEmail": "myemail@example.com",
+      "ReplyTo": "myemail@example.com",
+      "SentDate": "2010-10-06 16:20:00",
+      "TotalRecipients": 11222
+    }
+  ],
+  "ResultsOrderedBy": "SentDate",
+  "OrderDirection": "desc",
+  "PageNumber": 1,
+  "PageSize": 2,
+  "RecordsOnThisPage": 2,
+  "TotalNumberOfRecords": 49,
+  "NumberOfPages": 25
+} 

--- a/tests/responses/campaigns.json
+++ b/tests/responses/campaigns.json
@@ -23,7 +23,8 @@
       "FromEmail": "myemail@example.com",
       "ReplyTo": "myemail@example.com",
       "SentDate": "2010-10-06 16:20:00",
-      "TotalRecipients": 11222
+      "TotalRecipients": 11222,
+      "Tags": []
     }
   ],
   "ResultsOrderedBy": "SentDate",

--- a/tests/responses/deleted_subscribers.json
+++ b/tests/responses/deleted_subscribers.json
@@ -4,6 +4,7 @@
       "EmailAddress": "subs+7t8787Y@example.com",
       "Name": "Person One",
       "Date": "2010-10-25 10:28:00",
+      "ListJoinedDate": "2010-10-25 10:28:00",
       "State": "Deleted",
       "CustomFields": [
         {
@@ -25,6 +26,7 @@
       "EmailAddress": "subs+7878787y8ggg@example.com",
       "Name": "Person Two",
       "Date": "2010-10-25 12:17:00",
+      "ListJoinedDate": "2010-10-25 10:28:00",
       "State": "Deleted",
       "CustomFields": [
         {
@@ -38,6 +40,7 @@
       "EmailAddress": "subs+7890909i0ggg@example.com",
       "Name": "Person Three",
       "Date": "2010-10-25 12:52:00",
+      "ListJoinedDate": "2010-10-25 10:28:00",
       "State": "Deleted",
       "CustomFields": [
         {
@@ -51,6 +54,7 @@
       "EmailAddress": "subs@example.com",
       "Name": "Person Four",
       "Date": "2010-10-27 13:13:00",
+      "ListJoinedDate": "2010-10-25 10:28:00",
       "State": "Deleted",
       "CustomFields": [],
       "ReadsEmailWith": ""
@@ -59,6 +63,7 @@
       "EmailAddress": "joey@example.com",
       "Name": "Person Five",
       "Date": "2010-10-27 13:13:00",
+      "ListJoinedDate": "2010-10-25 10:28:00",
       "State": "Deleted",
       "CustomFields": [],
       "ReadsEmailWith": "Gmail"

--- a/tests/responses/drafts.json
+++ b/tests/responses/drafts.json
@@ -8,7 +8,8 @@
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2010-08-19 16:08:00",
     "PreviewURL": "http://hello.createsend.com/t/ViewEmail/r/E97A7BB2E6983DA1/C67FD2F38AC4859C/",
-    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t"
+    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
+    "Tags": []
   },
   {
     "CampaignID": "2e928e982065d92627139208c8c01db1",
@@ -19,6 +20,7 @@
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2010-08-19 16:08:00",
     "PreviewURL": "http://hello.createsend.com/t/ViewEmail/r/E97A7BB2E6983DA1/C67FD2F38AC4859C/",
-    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t"
+    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
+    "Tags": ["Tag1", "Tag2"]
   }
 ]

--- a/tests/responses/scheduled.json
+++ b/tests/responses/scheduled.json
@@ -10,7 +10,8 @@
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2011-05-24 10:37:00",
     "PreviewURL": "http://createsend.com/t/r-DD543521A87C9B8B",
-    "PreviewTextURL": "http://createsend.com/t/r-DD543521A87C9B8B/t"
+    "PreviewTextURL": "http://createsend.com/t/r-DD543521A87C9B8B/t",
+    "Tags": ["Tag1", "Tag2"]
   },
   {
     "DateScheduled": "2011-05-29 11:20:00",
@@ -23,6 +24,7 @@
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2011-05-24 10:39:00",
     "PreviewURL": "http://createsend.com/t/r-DD913521A87C9B8B",
-    "PreviewTextURL": "http://createsend.com/t/r-DD913521A87C9B8B/t"
+    "PreviewTextURL": "http://createsend.com/t/r-DD913521A87C9B8B/t",
+    "Tags": []
   }
 ]

--- a/tests/responses/segment_subscribers.json
+++ b/tests/responses/segment_subscribers.json
@@ -4,6 +4,7 @@
       "EmailAddress": "personone@example.com",
       "Name": "Person One",
       "Date": "2010-10-27 13:13:00",
+      "ListJoinedDate": "2010-10-27 13:13:00",
       "State": "Active",
       "CustomFields": []
     },
@@ -11,6 +12,7 @@
       "EmailAddress": "persontwo@example.com",
       "Name": "Person Two",
       "Date": "2010-10-27 13:13:00",
+      "ListJoinedDate": "2010-10-27 13:13:00",
       "State": "Active",
       "CustomFields": []
     }

--- a/tests/responses/subscriber_details.json
+++ b/tests/responses/subscriber_details.json
@@ -2,6 +2,7 @@
   "EmailAddress": "subscriber@example.com",
   "Name": "Subscriber One",
   "Date": "2010-10-25 10:28:00",
+  "ListJoinedDate": "2010-10-25 10:28:00",
   "State": "Active",
   "CustomFields": [
     {

--- a/tests/responses/tags.json
+++ b/tests/responses/tags.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Name": "Tag One",
+    "NumberOfCampaigns": "120"
+  },
+  {
+    "Name": "Tag Two",
+    "NumberOfCampaigns": "62"
+  }
+]

--- a/tests/responses/unconfirmed_subscribers.json
+++ b/tests/responses/unconfirmed_subscribers.json
@@ -1,0 +1,39 @@
+{
+  "Results": [
+    {
+      "EmailAddress": "subs+7878787y8ggg@example.com",
+      "Name": "Person Two",
+      "Date": "2010-10-25 12:17:00",
+      "ListJoinedDate": "2010-10-25 10:28:00",
+      "State": "Unconfirmed",
+      "CustomFields": [
+        {
+          "Key": "website",
+          "Value": "http://subdomain.example.com"
+        }
+      ],
+      "ReadsEmailWith": "Gmail"
+    },
+    {
+      "EmailAddress": "subs+7890909i0ggg@example.com",
+      "Name": "Person Three",
+      "Date": "2010-10-25 12:52:00",
+      "ListJoinedDate": "2010-10-25 10:28:00",
+      "State": "Unconfirmed",
+      "CustomFields": [
+        {
+          "Key": "website",
+          "Value": "http://subdomain.example.com"
+        }
+      ],
+      "ReadsEmailWith": ""
+    }
+  ],
+  "ResultsOrderedBy": "email",
+  "OrderDirection": "asc",
+  "PageNumber": 1,
+  "PageSize": 1000,
+  "RecordsOnThisPage": 2,
+  "TotalNumberOfRecords": 2,
+  "NumberOfPages": 1
+}

--- a/tests/responses/unsubscribed_subscribers.json
+++ b/tests/responses/unsubscribed_subscribers.json
@@ -4,6 +4,7 @@
       "EmailAddress": "subscriber@example.com",
       "Name": "Unsub One",
       "Date": "2010-10-25 13:11:00",
+      "ListJoinedDate": "2010-10-25 13:11:00",
       "State": "Unsubscribed",
       "CustomFields": []
     },
@@ -11,6 +12,7 @@
       "EmailAddress": "subscriberone@example.com",
       "Name": "Subscriber",
       "Date": "2010-10-25 13:04:00",
+      "ListJoinedDate": "2010-10-25 13:04:00",
       "State": "Unsubscribed",
       "CustomFields": [
         {
@@ -23,6 +25,7 @@
       "EmailAddress": "example+1@example.com",
       "Name": "Example One",
       "Date": "2010-10-26 10:56:00",
+      "ListJoinedDate": "2010-10-26 10:56:00",
       "State": "Unsubscribed",
       "CustomFields": []
     },
@@ -30,6 +33,7 @@
       "EmailAddress": "example+2@example.com",
       "Name": "Example Two",
       "Date": "2010-10-26 10:56:00",
+      "ListJoinedDate": "2010-10-26 10:56:00",
       "State": "Unsubscribed",
       "CustomFields": []
     },
@@ -37,6 +41,7 @@
       "EmailAddress": "example+3@example.com",
       "Name": "Example Three",
       "Date": "2010-10-26 10:56:00",
+      "ListJoinedDate": "2010-10-26 10:56:00",
       "State": "Unsubscribed",
       "CustomFields": []
     }


### PR DESCRIPTION
## v7.0.0 - 22nd Nov, 2021

* Upgrades to Createsend API v3.3 which includes new breaking changes
* Breaking: client sent campaigns endpoint is now paginated and filtered
* Added new client tags endpoint
* Added support for returning campaign name as part of sent, draft and scheduled campaign endpoints
* Added support for returning campaign name as part of campaign summary endpoint
* Added sample script for get client tags endpoint

## Notes

Includes indentation fix, see [individual commit](https://github.com/campaignmonitor/createsend-php/commit/417fc61ad634121a4b08cad016df1d435d4ba309#diff-226571159e3d4a7b09e6811c60ce39f1605a8ec08b3eb15b4d17f1f4de548a97) for changes to response_tests.php