### PR TITLE
Update serialisation.php - utf8_encode is deprecated in php8.2

### DIFF
--- a/class/serialisation.php
+++ b/class/serialisation.php
@@ -35,7 +35,7 @@ if (!class_exists('CS_REST_BaseSerialiser')) {
                     if((function_exists('mb_detect_encoding') && mb_detect_encoding($v) !== 'UTF-8') || 
                        (function_exists('mb_check_encoding') && !mb_check_encoding($v, 'UTF-8'))) {
                         // The string is using some other encoding, make sure we utf-8 encode
-                        $v = utf8_encode($v);       
+                        $v = mb_convert_encoding($v, 'UTF-8', mb_list_encodings());       
                     }
                     
                     $data[$k] = $v;


### PR DESCRIPTION
In php8.2 utf8_encode nad utf8_decode is depricated.  You are already checking for mbstring extension and functions and if available you were then encoding the string.  This is simply setting the function to utilize the mbstring method to actually encode the string in a matter thatis compatible with php8.2.

https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated#utf8_encode-any-mbstring