### PR TITLE
COM-675: Remove the redundant D&S Mark Up options

### DIFF
--- a/csrest_clients.php
+++ b/csrest_clients.php
@@ -334,7 +334,6 @@ if (!class_exists('CS_REST_Clients')) {
          *         'BaseDesignSpamTestRate' => The base fee payable per design and spam test
          *         'MarkupOnDelivery' => The markup applied per campaign
          *         'MarkupPerRecipient' => The markup applied per campaign recipient
-         *         'MarkupOnDesignSpamTest' => The markup applied per design and spam test
          *         'Currency' => The currency fees are paid in
          *         'ClientPays' => Whether client client pays for themselves
          *     }     
@@ -410,7 +409,6 @@ if (!class_exists('CS_REST_Clients')) {
          *             'CanPurchaseCredits' => Whether the client can purchase credits
          *             'MarkupOnDelivery' => The markup applied per campaign
          *             'MarkupPerRecipient' => The markup applied per campaign recipient
-         *             'MarkupOnDesignSpamTest' => The markup applied per design and spam test
          *         )
          * @access public
          * @return CS_REST_Wrapper_Result A successful response will be empty

--- a/samples/client/set_payg_billing.php
+++ b/samples/client/set_payg_billing.php
@@ -12,7 +12,6 @@ $wrap = new CS_REST_Clients('Your client ID', $auth);
  *
  * MarkupOnDelivery
  * MarkupPerRecipient
- * MarkupOnDesignSpamTest
  *
  * fields
  */
@@ -22,8 +21,7 @@ $result = $wrap->set_payg_billing(array(
     'MarkupPercentage' => 100,
     'CanPurchaseCredits' => false/*,
 'MarkupOnDelivery' => 4,
-'MarkupPerRecipient' => 3,
-'MarkupOnDesignSpamTest' => 7 */
+'MarkupPerRecipient' => 3 */
 ));
 
 echo "Result of PUT /api/v3.1/clients/{id}/setpaygbilling\n<br />";

--- a/tests/all_tests.php
+++ b/tests/all_tests.php
@@ -3,7 +3,7 @@ require_once __DIR__.'/../vendor/autoload.php';
 require_once __DIR__.'/../vendor/simpletest/simpletest/autorun.php';
 require_once __DIR__.'/../vendor/simpletest/simpletest/mock_objects.php';
 
-// Running simpletest, you would need to run this using PHP version 7.3 or lower
+// Running simpletest, you would need to run this using PHP version 7.4.X (PHP 7.4.9 is recommended)
 
 class AllTests extends TestSuite {
     function __construct() {

--- a/tests/class_tests/response_tests.php
+++ b/tests/class_tests/response_tests.php
@@ -66,7 +66,6 @@ class CS_REST_TestResponseDeserialisation extends UnitTestCase {
                 ),
                 'BillingDetails' => array(
                     'CanPurchaseCredits' => true,
-                    'MarkupOnDesignSpamTest' => 0,
                     'ClientPays' => true,
                     'BaseRatePerRecipient' => 1,
                     'MarkupPerRecipient' => 0,

--- a/tests/responses/client_details.json
+++ b/tests/responses/client_details.json
@@ -8,7 +8,6 @@
   },
   "BillingDetails": {
      "CanPurchaseCredits": true,
-     "MarkupOnDesignSpamTest": 0.0,
      "ClientPays": true,
      "BaseRatePerRecipient": 1.0,
      "MarkupPerRecipient": 0.0,


### PR DESCRIPTION
As titled.
I've also written a documentation on how to set up and test the wrapper: [Working with the Createsend PHP Wrapper
](https://campaignmonitor.atlassian.net/wiki/x/PoCzS)

|csrest_clients_test.php -> `set_payg_billing`|
|-----------------------|
| All tests passed ![image](https://github.com/user-attachments/assets/8c1be6fa-a8cd-4946-b04e-b7105393c930)|
